### PR TITLE
Add basic embedded overrides support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "prettier-plugin-embed",
       "version": "0.2.5",
       "license": "MIT",
+      "dependencies": {
+        "micro-memoize": "^4.1.2"
+      },
       "devDependencies": {
         "@commitlint/cli": "^18.4.2",
         "@commitlint/config-conventional": "^18.4.2",
@@ -6947,6 +6950,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micro-memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.1.2.tgz",
+      "integrity": "sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g=="
     },
     "node_modules/micromatch": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "prettier": "^3.0.0",
     "prettier-plugin-glsl": ">=0.1.2 <1",
     "prettier-plugin-sql": ">=0.15.0 <1"
+  },
+  "dependencies": {
+    "micro-memoize": "^4.1.2"
   }
 }

--- a/src/embedded/css/embedder.ts
+++ b/src/embedded/css/embedder.ts
@@ -5,6 +5,7 @@ import {
   printTemplateExpressions,
   preparePlaceholder,
   simpleRehydrateDoc,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 
@@ -17,6 +18,11 @@ export const embedder: Embedder<Options> = async (
   options,
   identifier,
 ) => {
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
+
   const { node } = path;
 
   const { createPlaceholder, placeholderRegex } = preparePlaceholder("@p");

--- a/src/embedded/css/embedder.ts
+++ b/src/embedded/css/embedder.ts
@@ -35,6 +35,7 @@ export const embedder: Embedder<Options> = async (
   const expressionDocs = printTemplateExpressions(path, print);
 
   const doc = await textToDoc(text, {
+    ...options,
     parser: "scss",
   });
 

--- a/src/embedded/es/embedder.ts
+++ b/src/embedded/es/embedder.ts
@@ -5,6 +5,7 @@ import {
   printTemplateExpressions,
   preparePlaceholder,
   simpleRehydrateDoc,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 
@@ -17,6 +18,11 @@ export const embedder: Embedder<Options> = async (
   options,
   identifier,
 ) => {
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
+
   const { node } = path;
 
   const { createPlaceholder, placeholderRegex } = preparePlaceholder();

--- a/src/embedded/es/embedder.ts
+++ b/src/embedded/es/embedder.ts
@@ -35,6 +35,7 @@ export const embedder: Embedder<Options> = async (
   const expressionDocs = printTemplateExpressions(path, print);
 
   const doc = await textToDoc(text, {
+    ...options,
     parser: options.embeddedEsParser ?? "babel",
   });
 

--- a/src/embedded/glsl/embedder.ts
+++ b/src/embedded/glsl/embedder.ts
@@ -6,6 +6,7 @@ import {
   throwIfPluginIsNotFound,
   preparePlaceholder,
   simpleRehydrateDoc,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 
@@ -19,6 +20,11 @@ export const embedder: Embedder<Options> = async (
   identifier,
 ) => {
   throwIfPluginIsNotFound("prettier-plugin-glsl", options, identifier);
+
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
 
   const { node } = path;
 

--- a/src/embedded/glsl/embedder.ts
+++ b/src/embedded/glsl/embedder.ts
@@ -43,6 +43,7 @@ export const embedder: Embedder<Options> = async (
   const expressionDocs = printTemplateExpressions(path, print);
 
   const doc = await textToDoc(trimmedText, {
+    ...options,
     parser: "glsl-parser",
   });
 

--- a/src/embedded/html/embedder.ts
+++ b/src/embedded/html/embedder.ts
@@ -1,7 +1,11 @@
 import { type Options } from "prettier";
 import { builders, utils } from "prettier/doc";
 import type { Embedder } from "../../types.js";
-import { printTemplateExpressions, preparePlaceholder } from "../utils.js";
+import {
+  printTemplateExpressions,
+  preparePlaceholder,
+  parseEmbeddedOverrideOptions,
+} from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 
 const { line, group, indent, softline } = builders;
@@ -14,6 +18,11 @@ export const embedder: Embedder<Options> = async (
   options,
   identifier,
 ) => {
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
+
   const { node } = path;
 
   const { createPlaceholder, placeholderRegex } = preparePlaceholder();

--- a/src/embedded/html/embedder.ts
+++ b/src/embedded/html/embedder.ts
@@ -32,6 +32,7 @@ export const embedder: Embedder<Options> = async (
   const expressionDocs = printTemplateExpressions(path, print);
 
   const doc = await textToDoc(text, {
+    ...options,
     parser: "html",
   });
 

--- a/src/embedded/markdown/embedder.ts
+++ b/src/embedded/markdown/embedder.ts
@@ -5,6 +5,7 @@ import {
   printTemplateExpressions,
   preparePlaceholder,
   simpleRehydrateDoc,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 
@@ -17,6 +18,11 @@ export const embedder: Embedder<Options> = async (
   options,
   identifier,
 ) => {
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
+
   const { node } = path;
 
   const { createPlaceholder, placeholderRegex } = preparePlaceholder();

--- a/src/embedded/markdown/embedder.ts
+++ b/src/embedded/markdown/embedder.ts
@@ -35,6 +35,7 @@ export const embedder: Embedder<Options> = async (
   const expressionDocs = printTemplateExpressions(path, print);
 
   const doc = await textToDoc(text, {
+    ...options,
     parser: "markdown",
     __inJsTemplate: true,
   });

--- a/src/embedded/php/embedder.ts
+++ b/src/embedded/php/embedder.ts
@@ -6,6 +6,7 @@ import {
   throwIfPluginIsNotFound,
   preparePlaceholder,
   simpleRehydrateDoc,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 
@@ -19,6 +20,11 @@ export const embedder: Embedder<Options> = async (
   identifier,
 ) => {
   throwIfPluginIsNotFound("@prettier/plugin-php", options, identifier);
+
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
 
   const { node } = path;
 

--- a/src/embedded/php/embedder.ts
+++ b/src/embedded/php/embedder.ts
@@ -43,6 +43,7 @@ export const embedder: Embedder<Options> = async (
   const expressionDocs = printTemplateExpressions(path, print);
 
   const doc = await textToDoc(trimmedText, {
+    ...options,
     parser: "php",
   });
 

--- a/src/embedded/ruby/embedder.ts
+++ b/src/embedded/ruby/embedder.ts
@@ -55,6 +55,7 @@ export const embedder: Embedder<Options> = async (
   const parser = getParser(options, identifier, identifiers);
 
   const doc = await textToDoc(trimmedText, {
+    ...options,
     parser,
   });
 

--- a/src/embedded/ruby/embedder.ts
+++ b/src/embedded/ruby/embedder.ts
@@ -6,6 +6,7 @@ import {
   throwIfPluginIsNotFound,
   preparePlaceholder,
   simpleRehydrateDoc,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 import {
@@ -29,6 +30,11 @@ export const embedder: Embedder<Options> = async (
   identifiers,
 ) => {
   throwIfPluginIsNotFound("@prettier/plugin-ruby", options, identifier);
+
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
 
   const { node } = path;
 

--- a/src/embedded/sql/embedder.ts
+++ b/src/embedded/sql/embedder.ts
@@ -6,6 +6,7 @@ import {
   printTemplateExpressions,
   throwIfPluginIsNotFound,
   preparePlaceholder,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import {
   NODE_SQL_PARSER_DATABASES,
@@ -27,6 +28,16 @@ export const embedder: Embedder<Options> = async (
   identifiers,
 ) => {
   throwIfPluginIsNotFound("prettier-plugin-sql", options, identifier);
+
+  const embeddedOverrideOptions = parseEmbeddedOverrideOptions(
+    options.embeddedOverrides,
+    identifier,
+  );
+
+  options = {
+    ...options,
+    ...embeddedOverrideOptions,
+  };
 
   const { node } = path;
 
@@ -54,6 +65,7 @@ export const embedder: Embedder<Options> = async (
     ...options,
     parser: "sql",
     ...optionsOverride,
+    ...embeddedOverrideOptions,
   });
 
   const contentDoc = mapDoc(doc, (doc) => {

--- a/src/embedded/sql/embedder.ts
+++ b/src/embedded/sql/embedder.ts
@@ -51,6 +51,7 @@ export const embedder: Embedder<Options> = async (
   }
 
   const doc = await textToDoc(text, {
+    ...options,
     parser: "sql",
     ...optionsOverride,
   });

--- a/src/embedded/ts/embedder.ts
+++ b/src/embedded/ts/embedder.ts
@@ -5,6 +5,7 @@ import {
   printTemplateExpressions,
   preparePlaceholder,
   simpleRehydrateDoc,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 
@@ -17,6 +18,11 @@ export const embedder: Embedder<Options> = async (
   options,
   identifier,
 ) => {
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
+
   const { node } = path;
 
   const { createPlaceholder, placeholderRegex } = preparePlaceholder();

--- a/src/embedded/ts/embedder.ts
+++ b/src/embedded/ts/embedder.ts
@@ -35,6 +35,7 @@ export const embedder: Embedder<Options> = async (
   const expressionDocs = printTemplateExpressions(path, print);
 
   const doc = await textToDoc(text, {
+    ...options,
     parser: options.embeddedTsParser ?? "typescript",
     // set filepath to undefined to enable jsx auto detection:
     // https://github.com/prettier/prettier/blob/427a84d24203e2d54160cde153a1e6a6390fe65a/src/language-js/parse/typescript.js#L49-L53

--- a/src/embedded/types.ts
+++ b/src/embedded/types.ts
@@ -27,7 +27,3 @@ export interface EmbeddedDefaultIdentifiersHolder {}
 export type EmbeddedDefaultIdentifier = keyof EmbeddedDefaultIdentifiersHolder;
 
 export interface PrettierPluginEmbedOptions {}
-
-declare module "prettier" {
-  interface Options extends PrettierPluginEmbedOptions {}
-}

--- a/src/embedded/xml/embedder.ts
+++ b/src/embedded/xml/embedder.ts
@@ -6,6 +6,7 @@ import {
   throwIfPluginIsNotFound,
   preparePlaceholder,
   simpleRehydrateDoc,
+  parseEmbeddedOverrideOptions,
 } from "../utils.js";
 import { embeddedLanguage } from "./embedded-language.js";
 
@@ -19,6 +20,11 @@ export const embedder: Embedder<Options> = async (
   identifier,
 ) => {
   throwIfPluginIsNotFound("@prettier/plugin-xml", options, identifier);
+
+  options = {
+    ...options,
+    ...parseEmbeddedOverrideOptions(options.embeddedOverrides, identifier),
+  };
 
   const { node } = path;
 

--- a/src/embedded/xml/embedder.ts
+++ b/src/embedded/xml/embedder.ts
@@ -58,6 +58,7 @@ export const embedder: Embedder<Options> = async (
       options.__embeddedXmlFragmentRecoverIndex.length,
     );
     let printedText = await textToDoc(textFragment, {
+      ...options,
       parser: embeddedLanguage,
     });
     const [i1, i2] = options.__embeddedXmlFragmentRecoverIndex ?? [];

--- a/src/options.ts
+++ b/src/options.ts
@@ -56,18 +56,20 @@ export const options = {
     array: false,
     default: undefined,
     description:
-      "This option accepts option overrides for embedded languages. It should either be a stringified JSON or an absolute filepath to the option overrides file.",
+      "This option accepts option overrides for the specified identifiers. It should either be a stringified JSON or an absolute filepath to the option overrides file.",
   },
 } satisfies SupportOptions & Record<string, { category: CoreCategoryType }>;
 
+export interface PrettierPluginGlobalOptions {
+  [NO_EMBEDDED_IDENTIFICATION_BY_COMMENT]?: EmbeddedIdentifiers;
+  [NO_EMBEDDED_IDENTIFICATION_BY_TAG]?: EmbeddedIdentifiers;
+  [PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES]?: EmbeddedIdentifiers;
+  [NO_EMBEDDED_MULTI_LINE_INDENTATION]?: EmbeddedIdentifiers;
+  [EMBEDDED_OVERRIDES]?: string;
+}
+
 declare module "./embedded/types.js" {
-  interface PrettierPluginEmbedOptions {
-    [NO_EMBEDDED_IDENTIFICATION_BY_COMMENT]?: EmbeddedIdentifiers;
-    [NO_EMBEDDED_IDENTIFICATION_BY_TAG]?: EmbeddedIdentifiers;
-    [PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES]?: EmbeddedIdentifiers;
-    [NO_EMBEDDED_MULTI_LINE_INDENTATION]?: EmbeddedIdentifiers;
-    [EMBEDDED_OVERRIDES]?: string;
-  }
+  interface PrettierPluginEmbedOptions extends PrettierPluginGlobalOptions {}
 }
 
 declare module "prettier" {

--- a/src/options.ts
+++ b/src/options.ts
@@ -14,6 +14,7 @@ const NO_EMBEDDED_IDENTIFICATION_BY_TAG = "noEmbeddedIdentificationByTag";
 const PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES =
   "preserveEmbeddedExteriorWhitespaces";
 const NO_EMBEDDED_MULTI_LINE_INDENTATION = "noEmbeddedMultiLineIndentation";
+const EMBEDDED_OVERRIDES = "embeddedOverrides";
 
 export const options = {
   ...embeddedOptions,
@@ -49,6 +50,14 @@ export const options = {
     description:
       "This option turns off auto indentation in the formatting results for the specified identifiers when they are formatted to span multi lines.",
   },
+  [EMBEDDED_OVERRIDES]: {
+    category: "Global",
+    type: "string",
+    array: false,
+    default: undefined,
+    description:
+      "This option accepts option overrides for embedded languages. It should either be a stringified JSON or an absolute filepath to the option overrides file.",
+  },
 } satisfies SupportOptions & Record<string, { category: CoreCategoryType }>;
 
 declare module "./embedded/types.js" {
@@ -57,6 +66,7 @@ declare module "./embedded/types.js" {
     [NO_EMBEDDED_IDENTIFICATION_BY_TAG]?: EmbeddedIdentifiers;
     [PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES]?: EmbeddedIdentifiers;
     [NO_EMBEDDED_MULTI_LINE_INDENTATION]?: EmbeddedIdentifiers;
+    [EMBEDDED_OVERRIDES]?: string;
   }
 }
 

--- a/src/printers.ts
+++ b/src/printers.ts
@@ -2,9 +2,7 @@ import type { TemplateLiteral } from "estree";
 import type { Plugin, Printer, AstPath, Options } from "prettier";
 import { builders } from "prettier/doc";
 import { printers as estreePrinters } from "prettier/plugins/estree.mjs";
-import { isAbsolute } from "node:path";
-import { readFileSync } from "node:fs";
-import type { EmbeddedOverrides, PrettierNode } from "./types.js";
+import type { PrettierNode } from "./types.js";
 import {
   embeddedLanguages,
   embeddedEmbedders,
@@ -62,7 +60,7 @@ const embed: Printer["embed"] = function (
           textToDoc,
           print,
           path,
-          getOptionsWithOverrides(options, identifier),
+          options,
           identifier,
           identifiers,
         );
@@ -143,30 +141,6 @@ function getIdentifierFromTag(
     }
   }
   return;
-}
-
-function getOptionsWithOverrides(
-  options: Options,
-  identifier: string,
-): Options {
-  const { embeddedOverrides } = options;
-  if (typeof embeddedOverrides === "string") {
-    const stringifiedOverrides = isAbsolute(embeddedOverrides)
-      ? readFileSync(embeddedOverrides, { encoding: "utf-8" })
-      : embeddedOverrides;
-    try {
-      const overrides = JSON.parse(stringifiedOverrides) as EmbeddedOverrides;
-      for (const { identifiers, options: overrideOptions } of overrides) {
-        if (!identifiers.includes(identifier)) {
-          continue;
-        }
-        return { ...options, ...overrideOptions };
-      }
-    } catch {
-      /* void */
-    }
-  }
-  return options;
 }
 
 // extends estree printer to parse embedded lanaguges in js/ts files

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 import type { Options, Doc, AstPath } from "prettier";
 import type { Node as EsTreeNode, TemplateLiteral, Comment } from "estree";
+import type {
+  EmbeddedDefaultIdentifier,
+  AutocompleteStringList,
+} from "./embedded/index.js";
 
 export type PrettierNode = EsTreeNode & {
   comments?: (Comment & {
@@ -21,3 +25,11 @@ export type Embedder<T extends Options = Options> = (
   identifier: string,
   identifiers: string[],
 ) => Promise<Doc>;
+
+export interface EmbeddedOverride {
+  identifiers: AutocompleteStringList<EmbeddedDefaultIdentifier[]>;
+  // TODO: Options type is a little too wide
+  options: Options;
+}
+
+export type EmbeddedOverrides = EmbeddedOverride[];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
 /// <reference types="vitest" />
 import { defineConfig } from "vite";
 import { peerDependencies } from "./package.json";
+import { builtinModules } from "node:module";
 
 export default defineConfig({
   build: {
+    target: ["node18"],
     lib: {
       entry: {
         index: "./src/index.ts",
@@ -14,7 +16,12 @@ export default defineConfig({
     },
     copyPublicDir: false,
     rollupOptions: {
-      external: [/^@?prettier(?:\/|$)/, ...Object.keys(peerDependencies ?? {})],
+      external: [
+        /^@?prettier(?:\/|$)/,
+        ...Object.keys(peerDependencies ?? {}),
+        ...builtinModules,
+        /^node:/,
+      ],
     },
   },
   test: {


### PR DESCRIPTION
This is a preliminary attempt to add option overrides support for embedded languages, see https://github.com/Sec-ant/prettier-plugin-embed/issues/16#issuecomment-1783658897

- Add a new option `embeddedOverrides`. This option accepts a stringified json string or an absolute json file path as its value.
- The value should be in the following form, an example 👇:
  ```json
  [
    {
      "identifiers": [
        "sql"
      ],
      "options": {
        "keywordCase": "lower",
        "indentStyle": "tabularRight"
      }
    },
    {
      "identifiers": [
        "mysql"
      ],
      "options": {
        "keywordCase": "upper"
      }
    }
  ]
  ```

**Note**: Not all options are supported for overriding. Check the interface definition:

```ts
export interface EmbeddedOverride {
  identifiers: AutocompleteStringList<EmbeddedDefaultIdentifier[]>;
  options: Omit<
    // native prettier options
    Omit<Options, keyof PrettierPluginEmbedOptions> &
      // prettier-plugin-embed options
      // except for "embedded<Language>Identifiers"
      // and global options
      // (they should be set globally, not in overrides)
      Omit<
        PrettierPluginEmbedOptions,
        | keyof PrettierPluginGlobalOptions
        | ReturnType<typeof makeIdentifiersOptionName<EmbeddedLanguage>>
      >,
    // these options are used in `printDocToString`,
    // we cannot override them because plugins can only affect ast and doc generation at most
    // check: https://github.com/prettier/prettier/blob/7aecca5d6473d73f562ca3af874831315f8f2581/src/document/printer.js
    | "printWidth"
    | "endOfLine"
    | "useTabs"
    | "tabWidth"
    // some other options we don't want to expose to the users or don't make sense to override
    | "parser"
    | "filepath"
    | "embeddedLanguageFormatting"
    | `__${string}`
  >;
}
```