### PR TITLE
Relax peerDependencies semver ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,14 +82,14 @@
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "@prettier/plugin-php": "^0.20.1",
+    "@prettier/plugin-php": ">=0.20.1 <1",
     "@prettier/plugin-ruby": "^4.0.0",
     "@prettier/plugin-xml": "^3.1.0",
     "@xml-tools/parser": "^1.0.11",
     "chevrotain": "7.1.1",
     "prettier": "^3.0.0",
-    "prettier-plugin-glsl": "^0.1.2",
-    "prettier-plugin-sql": "^0.15.0"
+    "prettier-plugin-glsl": ">=0.1.2 <1",
+    "prettier-plugin-sql": ">=0.16.0 <1"
   },
   "dependencies": {
     "short-unique-id": "^5.0.3"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "chevrotain": "7.1.1",
     "prettier": "^3.0.0",
     "prettier-plugin-glsl": ">=0.1.2 <1",
-    "prettier-plugin-sql": ">=0.16.0 <1"
+    "prettier-plugin-sql": ">=0.15.0 <1"
   },
   "dependencies": {
     "short-unique-id": "^5.0.3"


### PR DESCRIPTION
Hi @Sec-ant 👋 hope you're well

For `peerDependencies` with packages having current versions less than 1, allow for all versions up until version 1

This avoids warnings such as this one from pnpm, which I received after I upgraded to `prettier-plugin-sql@0.16.0`:

```
 WARN  Issues with peer dependencies found
.
└─┬ prettier-plugin-embed 0.2.5
  └── ✕ unmet peer prettier-plugin-sql@^0.15.0: found 0.16.0
```