### PR TITLE
Add Config Examples section

### DIFF
--- a/ConfigExamples.md
+++ b/ConfigExamples.md
@@ -1,0 +1,69 @@
+# Config Examples
+
+## `prettier-plugin-sql`
+
+Format SQL-in-JS with [`prettier-plugin-sql`](https://github.com/un-ts/prettier/tree/master/packages/sql) ([options](https://github.com/un-ts/prettier/tree/master/packages/sql#parser-options))
+
+`prettier.config.mjs`
+
+```js
+/** @type {import('prettier').Config} */
+const prettierConfig = {
+  plugins: ["prettier-plugin-embed", "prettier-plugin-sql"],
+};
+
+/** @type {import('prettier-plugin-embed').PrettierPluginEmbedOptions} */
+const prettierPluginEmbedConfig = {
+  embeddedSqlIdentifiers: ["sql"],
+};
+
+/** @type {import('prettier-plugin-sql').SqlBaseOptions} */
+const prettierPluginSqlConfig = {
+  language: "postgresql",
+  keywordCase: "upper",
+};
+
+const config = {
+  ...prettierConfig,
+  ...prettierPluginEmbedConfig,
+  ...prettierPluginSqlConfig,
+};
+
+export default config;
+```
+
+Before formatting:
+
+```ts
+const users = await sql`
+        sELect       users.first_name,
+users.email        ,
+          companies.id 
+as    employer_company_id
+            froM  users
+LefT JOIn
+    employers ON
+      users.id
+  = employers.user_id
+    LefT JOIn
+      companies ON
+employers.company_id = companies.id WHERE users.id = ${userId}
+`;
+```
+
+After formatting:
+
+```ts
+const users = await sql`
+  SELECT
+    users.first_name,
+    users.email,
+    companies.id AS employer_company_id
+  FROM
+    users
+    LEFT JOIN employers ON users.id = employers.user_id
+    LEFT JOIN companies ON employers.company_id = companies.id
+  WHERE
+    users.id = ${userId}
+`;
+```

--- a/README.md
+++ b/README.md
@@ -227,6 +227,76 @@ An example `.json` file is:
 
 Please note that not every option is supported to override. That largely depends on at which phase those options will kick in and take effect. For example, you can't override `tabWidth` in `embeddedOverrides` because this option is used in the [`printDocToString`](https://github.com/prettier/prettier/blob/7aecca5d6473d73f562ca3af874831315f8f2581/src/document/printer.js#L302) phase, where `prettier-plugin-embed` cannot override this option for only a set of specified identifiers. To find the list of unsupported options, please check the interface definition of `EmbeddedOverride` in the [source code](https://github.com/Sec-ant/prettier-plugin-embed/blob/main/src/types.ts).
 
+### Config Examples
+
+#### `prettier-plugin-sql`
+
+Format SQL-in-JS with [`prettier-plugin-sql`](https://github.com/un-ts/prettier/tree/master/packages/sql) ([options](https://github.com/un-ts/prettier/tree/master/packages/sql#parser-options))
+
+`prettier.config.mjs`
+
+```js
+/** @type {import('prettier').Config} */
+const prettierConfig = {
+  plugins: ['prettier-plugin-embed', 'prettier-plugin-sql'],
+};
+
+/** @type {import('prettier-plugin-embed').PrettierPluginEmbedOptions} */
+const prettierPluginEmbedConfig = {
+  embeddedSqlIdentifiers: ['sql'],
+}
+
+/** @type {import('prettier-plugin-sql').SqlBaseOptions} */
+const prettierPluginSqlConfig = {
+  language: 'postgresql',
+  keywordCase: 'upper',
+}
+
+const config = {
+  ...prettierConfig,
+  ...prettierPluginEmbedConfig,
+  ...prettierPluginSqlConfig,
+};
+
+export default config;
+```
+
+Before formatting:
+
+```ts
+const users = await sql`
+        sELect       users.first_name,
+users.email        ,
+          companies.id 
+as    employer_company_id
+            froM  users
+LefT JOIn
+    employers ON
+      users.id
+  = employers.user_id
+    LefT JOIn
+      companies ON
+employers.company_id = companies.id WHERE users.id = ${userId}
+`;
+```
+
+After formatting:
+
+```ts
+const users = await sql`
+  SELECT
+    users.first_name,
+    users.email,
+    companies.id AS employer_company_id
+  FROM
+    users
+    LEFT JOIN employers ON users.id = employers.user_id
+    LEFT JOIN companies ON employers.company_id = companies.id
+  WHERE
+    users.id = ${userId}
+`;
+```
+
 ### An Overview of the Philosophy
 
 To use this plugin, [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option must be set to `auto` (which is the default setting as of now), because this option serves as the main switch for activating embedded language formatting.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,24 @@ await prettier.format(code, {
 }
 ```
 
+### Quick Start Config Examples
+
+Here're some [quick start config examples](./ConfigExamples.md) to use this plugin for various embedded languages. Check beblow for a detailed explanation of all the available options.
+
+### An Overview of the Philosophy
+
+To use this plugin, [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option must be set to `auto` (which is the default setting as of now), because this option serves as the main switch for activating embedded language formatting.
+
+This plugin does not aim to implement parsers or printers to support every newly added embedded language. Instead, ideally, it makes use of existing [Prettier plugins](https://prettier.io/docs/en/plugins.html#official-plugins) for those languages and only adds formatting support when they are embedded in template literals.
+
+Therefore, to enable formatting for a specific embedded language, the corresponding Prettier plugin for that language must also be loaded. For example, if you wish to format embedded XML code, you will need to load both this plugin and [`@prettier/plugin-xml`](https://github.com/prettier/plugin-xml). To find out which other plugins are required when using this plugin, please refer to the [Language-Specific Options](#language-specific-options) section below.
+
+Embedded languages to be formatted are required to be enclosed in the template literals, and are identified by the preceding [tags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) `` identifier`...` `` or [block comments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#block_comments) `` /* identifier */ `...` ``. This plugin comes pre-configured with a built-in set of identifiers for identifying various embedded languages. For instance, using identifiers like `xml` or `svg` will trigger automatic formatting for the embedded XML code. You can specify an alternative list of identifiers using the `embeddedXmlIdentifiers` option. The naming convention for these options follows the pattern of `embedded<Language>Identifiers` for other languages as well. Further details on these options and how to configure them are also available in the [Language-Specific Options](#language-specific-options) section.
+
+To exclude certain identifiers from being identified, including the default ones supported by the [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option, add them to the list of the `embeddedNoopIdentifiers` option. Any matching identifiers listed in this option will take precedence over other `embedded<Language>Identifiers` options, effectively disabling their formatting.
+
+**Important: Until this notice is removed, always specify identifiers explicitly and do not rely on the built-in defaults, as they may be subject to change.**
+
 ### Language-Specific Options
 
 <details>
@@ -226,94 +244,6 @@ An example `.json` file is:
 ```
 
 Please note that not every option is supported to override. That largely depends on at which phase those options will kick in and take effect. For example, you can't override `tabWidth` in `embeddedOverrides` because this option is used in the [`printDocToString`](https://github.com/prettier/prettier/blob/7aecca5d6473d73f562ca3af874831315f8f2581/src/document/printer.js#L302) phase, where `prettier-plugin-embed` cannot override this option for only a set of specified identifiers. To find the list of unsupported options, please check the interface definition of `EmbeddedOverride` in the [source code](https://github.com/Sec-ant/prettier-plugin-embed/blob/main/src/types.ts).
-
-### Config Examples
-
-#### `prettier-plugin-sql`
-
-Format SQL-in-JS with [`prettier-plugin-sql`](https://github.com/un-ts/prettier/tree/master/packages/sql) ([options](https://github.com/un-ts/prettier/tree/master/packages/sql#parser-options))
-
-`prettier.config.mjs`
-
-```js
-/** @type {import('prettier').Config} */
-const prettierConfig = {
-  plugins: ['prettier-plugin-embed', 'prettier-plugin-sql'],
-};
-
-/** @type {import('prettier-plugin-embed').PrettierPluginEmbedOptions} */
-const prettierPluginEmbedConfig = {
-  embeddedSqlIdentifiers: ['sql'],
-}
-
-/** @type {import('prettier-plugin-sql').SqlBaseOptions} */
-const prettierPluginSqlConfig = {
-  language: 'postgresql',
-  keywordCase: 'upper',
-}
-
-const config = {
-  ...prettierConfig,
-  ...prettierPluginEmbedConfig,
-  ...prettierPluginSqlConfig,
-};
-
-export default config;
-```
-
-Before formatting:
-
-```ts
-const users = await sql`
-        sELect       users.first_name,
-users.email        ,
-          companies.id 
-as    employer_company_id
-            froM  users
-LefT JOIn
-    employers ON
-      users.id
-  = employers.user_id
-    LefT JOIn
-      companies ON
-employers.company_id = companies.id WHERE users.id = ${userId}
-`;
-```
-
-After formatting:
-
-```ts
-const users = await sql`
-  SELECT
-    users.first_name,
-    users.email,
-    companies.id AS employer_company_id
-  FROM
-    users
-    LEFT JOIN employers ON users.id = employers.user_id
-    LEFT JOIN companies ON employers.company_id = companies.id
-  WHERE
-    users.id = ${userId}
-`;
-```
-
-### An Overview of the Philosophy
-
-To use this plugin, [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option must be set to `auto` (which is the default setting as of now), because this option serves as the main switch for activating embedded language formatting.
-
-This plugin does not aim to implement parsers or printers to support every newly added embedded language. Instead, ideally, it makes use of existing [Prettier plugins](https://prettier.io/docs/en/plugins.html#official-plugins) for those languages and only adds formatting support when they are embedded in template literals.
-
-Therefore, to enable formatting for a specific embedded language, the corresponding Prettier plugin for that language must also be loaded. For example, if you wish to format embedded XML code, you will need to load both this plugin and [`@prettier/plugin-xml`](https://github.com/prettier/plugin-xml). To find out which other plugins are required when using this plugin, please refer to the [Language-Specific Options](#language-specific-options) section below.
-
-Embedded languages to be formatted are required to be enclosed in the template literals, and are identified by the preceding [tags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) `` identifier`...` `` or [block comments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#block_comments) `` /* identifier */ `...` ``. This plugin comes pre-configured with a built-in set of identifiers for identifying various embedded languages. For instance, using identifiers like `xml` or `svg` will trigger automatic formatting for the embedded XML code. You can specify an alternative list of identifiers using the `embeddedXmlIdentifiers` option. The naming convention for these options follows the pattern of `embedded<Language>Identifiers` for other languages as well. Further details on these options and how to configure them are also available in the [Language-Specific Options](#language-specific-options) section.
-
-To exclude certain identifiers from being identified, including the default ones supported by the [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option, add them to the list of the `embeddedNoopIdentifiers` option. Any matching identifiers listed in this option will take precedence over other `embedded<Language>Identifiers` options, effectively disabling their formatting.
-
-**Important: Until this notice is removed, always specify identifiers explicitly and do not rely on the built-in defaults, as they may be subject to change.**
-
-## Demos
-
-TBD.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -86,20 +86,6 @@ await prettier.format(code, {
 }
 ```
 
-### An Overview of the Philosophy
-
-To use this plugin, [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option must be set to `auto` (which is the default setting as of now), because this option serves as the main switch for activating embedded language formatting.
-
-This plugin does not aim to implement parsers or printers to support every newly added embedded language. Instead, ideally, it makes use of existing [Prettier plugins](https://prettier.io/docs/en/plugins.html#official-plugins) for those languages and only adds formatting support when they are embedded in template literals.
-
-Therefore, to enable formatting for a specific embedded language, the corresponding Prettier plugin for that language must also be loaded. For example, if you wish to format embedded XML code, you will need to load both this plugin and [`@prettier/plugin-xml`](https://github.com/prettier/plugin-xml). To find out which other plugins are required when using this plugin, please refer to the [Language-Specific Options](#language-specific-options) section below.
-
-Embedded languages to be formatted are required to be enclosed in the template literals, and are identified by the preceding [tags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) `` identifier`...` `` or [block comments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#block_comments) `` /* identifier */ `...` ``. This plugin comes pre-configured with a built-in set of identifiers for identifying various embedded languages. For instance, using identifiers like `xml` or `svg` will trigger automatic formatting for the embedded XML code. You can specify an alternative list of identifiers using the `embeddedXmlIdentifiers` option. The naming convention for these options follows the pattern of `embedded<Language>Identifiers` for other languages as well. Further details on these options and how to configure them are also available in the [Language-Specific Options](#language-specific-options) section.
-
-To exclude certain identifiers from being identified, including the default ones supported by the [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option, add them to the list of the `embeddedNoopIdentifiers` option. Any matching identifiers listed in this option will take precedence over other `embedded<Language>Identifiers` options, effectively disabling their formatting.
-
-**Important: Until this notice is removed, always specify identifiers explicitly and do not rely on the built-in defaults, as they may be subject to change.**
-
 ### Language-Specific Options
 
 <details>
@@ -240,6 +226,20 @@ An example `.json` file is:
 ```
 
 Please note that not every option is supported to override. That largely depends on at which phase those options will kick in and take effect. For example, you can't override `tabWidth` in `embeddedOverrides` because this option is used in the [`printDocToString`](https://github.com/prettier/prettier/blob/7aecca5d6473d73f562ca3af874831315f8f2581/src/document/printer.js#L302) phase, where `prettier-plugin-embed` cannot override this option for only a set of specified identifiers. To find the list of unsupported options, please check the interface definition of `EmbeddedOverride` in the [source code](https://github.com/Sec-ant/prettier-plugin-embed/blob/main/src/types.ts).
+
+### An Overview of the Philosophy
+
+To use this plugin, [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option must be set to `auto` (which is the default setting as of now), because this option serves as the main switch for activating embedded language formatting.
+
+This plugin does not aim to implement parsers or printers to support every newly added embedded language. Instead, ideally, it makes use of existing [Prettier plugins](https://prettier.io/docs/en/plugins.html#official-plugins) for those languages and only adds formatting support when they are embedded in template literals.
+
+Therefore, to enable formatting for a specific embedded language, the corresponding Prettier plugin for that language must also be loaded. For example, if you wish to format embedded XML code, you will need to load both this plugin and [`@prettier/plugin-xml`](https://github.com/prettier/plugin-xml). To find out which other plugins are required when using this plugin, please refer to the [Language-Specific Options](#language-specific-options) section below.
+
+Embedded languages to be formatted are required to be enclosed in the template literals, and are identified by the preceding [tags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) `` identifier`...` `` or [block comments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#block_comments) `` /* identifier */ `...` ``. This plugin comes pre-configured with a built-in set of identifiers for identifying various embedded languages. For instance, using identifiers like `xml` or `svg` will trigger automatic formatting for the embedded XML code. You can specify an alternative list of identifiers using the `embeddedXmlIdentifiers` option. The naming convention for these options follows the pattern of `embedded<Language>Identifiers` for other languages as well. Further details on these options and how to configure them are also available in the [Language-Specific Options](#language-specific-options) section.
+
+To exclude certain identifiers from being identified, including the default ones supported by the [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option, add them to the list of the `embeddedNoopIdentifiers` option. Any matching identifiers listed in this option will take precedence over other `embedded<Language>Identifiers` options, effectively disabling their formatting.
+
+**Important: Until this notice is removed, always specify identifiers explicitly and do not rely on the built-in defaults, as they may be subject to change.**
 
 ## Demos
 


### PR DESCRIPTION
Closes #20

- [x] Move philosophy section down below options
- [x] Add Config Examples section with `prettier-plugin-sql` example