### PR TITLE
feat: support `embeddedOverrides` config in more file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,13 +393,17 @@ Formatting embedded YAML language doesn't require other plugins and uses the par
 
 #### `embeddedOverrides`
 
-This option is provided for users to override certain options based on identifiers. Due to the lack of support for using objects in prettier plugin options (https://github.com/prettier/prettier/issues/14671), it accepts a **stringified** json string, or a file path with an extension of `.json` or `.js` or `.cjs` or `.mjs` as its value. If no extension is provided, it will be treated as a `.json` file. For relative paths, it will automatically figure out the prettier config location and use that as the base path.
+This option is provided for users to override certain options based on identifiers. Due to the lack of support for using objects in prettier plugin options (https://github.com/prettier/prettier/issues/14671), it accepts a **stringified** json string, or a file path with an extension of `.json`, `.jsonc`, `.js`, `.cjs`, `.mjs`, `.ts`, `.cts` or `.mts` as its value. If no extension is provided, it will be treated as a `.json`/`.jsonc` file. For relative paths, it will automatically figure out the prettier config location and use that as the base path.
+
+> [!NOTE]
+>
+> The support for using `.ts`, `.mts` or `.cts` files for `embeddedOverrides` requires a minimal `node` version of [18.19.0](https://nodejs.org/en/blog/release/v18.19.0#esm-and-customization-hook-changes), and [`tsx`](https://github.com/privatenumber/tsx) as a dependency in your project.
 
 The resolved value should be an array of objects. Each object in the array must have 2 fields: `identifiers` and `options`. The `options` are considerred overrides that will be applied to the global `options` of prettier for those `idenfitiers` only. It's like the [`overrides`](https://prettier.io/docs/en/configuration.html#configuration-overrides) of `prettier`, but it is identifier-based instead of file-based.
 
 In a json file, the root is the array of objects. In a JavaScript file, the array of objects should be a default export, or a named export with the name `embeddedOverrides`.
 
-An example `.json` file is:
+An example `.json`/`.jsonc` file is:
 
 ```json
 [

--- a/biome.json
+++ b/biome.json
@@ -32,5 +32,16 @@
     "clientKind": "git",
     "useIgnoreFile": true,
     "defaultBranch": "main"
-  }
+  },
+  "overrides": [
+    {
+      "include": ["*.jsonc"],
+      "json": {
+        "parser": {
+          "allowComments": true,
+          "allowTrailingCommas": true
+        }
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dedent": "^1.5.1",
         "micro-memoize": "^4.1.2",
         "package-up": "^5.0.0",
+        "tiny-jsonc": "^1.0.1",
         "type-fest": "^4.9.0"
       },
       "devDependencies": {
@@ -10744,6 +10745,11 @@
       "dependencies": {
         "readable-stream": "3"
       }
+    },
+    "node_modules/tiny-jsonc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-jsonc/-/tiny-jsonc-1.0.1.tgz",
+      "integrity": "sha512-ik6BCxzva9DoiEfDX/li0L2cWKPPENYvixUprFdl3YPi4bZZUhDnNI9YUkacrv+uIG90dnxR5mNqaoD6UhD6Bw=="
     },
     "node_modules/tinybench": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "dedent": "^1.5.1",
     "micro-memoize": "^4.1.2",
     "package-up": "^5.0.0",
+    "tiny-jsonc": "^1.0.1",
     "type-fest": "^4.9.0"
   }
 }

--- a/scripts/import-ts-module-worker.ts
+++ b/scripts/import-ts-module-worker.ts
@@ -1,7 +1,15 @@
+import { register } from "node:module";
 import { pathToFileURL } from "node:url";
 import { parentPort, workerData } from "node:worker_threads";
 
-const executeWorker = async ({ absolutePath }: { absolutePath: string }) => {
+const executeWorker = async ({
+  absolutePath,
+  importMetaUrl,
+}: { absolutePath: string; importMetaUrl: string }) => {
+  register("tsx/esm", {
+    parentURL: importMetaUrl,
+    data: true,
+  });
   try {
     const importedModule = await import(pathToFileURL(absolutePath).href);
     parentPort?.postMessage(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,17 @@ export default defineConfig({
         )
       ).code.trim(),
     ),
+    IMPORT_TS_MODULE_WORKER: JSON.stringify(
+      (
+        await transform(
+          await readFile("./scripts/import-ts-module-worker.ts"),
+          {
+            loader: "ts",
+            minify: true,
+          },
+        )
+      ).code.trim(),
+    ),
   },
   test: {
     passWithNoTests: true,


### PR DESCRIPTION
* Support `.jsonc`
* Support `.ts`, `.mts`, `.cts`. Requires `node` > 18.19.0 and `tsx` as a dependency. It doesn't work in the Prettier VSCode extension. 