### PR TITLE
Deprecate `identifier`-named options

### DIFF
--- a/.changeset/three-sloths-retire.md
+++ b/.changeset/three-sloths-retire.md
@@ -1,0 +1,25 @@
+---
+"prettier-plugin-embed": patch
+---
+
+Deprecate `identifier`-named options.
+
+- Change options `embedded<Language>Identifiers` to `embedded<Language>Comments` and `embedded<Language>Tags`.
+- Remove option ~~`noEmbeddedIdentificationByComment`~~ because it is not needed anymore.
+- Remove option ~~`noEmbeddedIdentificationByTag`~~ because it is not needded anymore.
+- `embeddedOverrides` now takes the form:
+  ```json
+  {"comments": [...], "options": {...}}
+  ```
+  or
+  ```json
+  {"tags": [...], "options": {...}}
+  ```
+  or
+  ```json
+  {"comments": [...], "tags": [...], "options": {...}}
+  ```
+  The property `identifiers` is kept for compatibility and will serve as fallbacks.
+- If `comment`- or `tag`-named options are not present, the plugin will fallback to use `identifier`-named options.
+- README updated to reflect the above changes.
+- **NO** breaking changes.

--- a/ConfigExamples.md
+++ b/ConfigExamples.md
@@ -18,7 +18,7 @@ const prettierConfig = {
  * @type {import("prettier-plugin-embed").PluginEmbedOptions}
  */
 const prettierPluginEmbedConfig = {
-  embeddedSqlIdentifiers: ["sql"],
+  embeddedSqlTags: ["sql"],
 };
 
 /**

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![github last commit](https://img.shields.io/github/last-commit/Sec-ant/prettier-plugin-embed?cacheSeconds=300)](https://github.com/Sec-ant/prettier-plugin-embed) [![bundlephobia minzipped](https://img.shields.io/bundlephobia/minzip/prettier-plugin-embed?cacheSeconds=300)](https://bundlephobia.com/package/prettier-plugin-embed@latest) [![](https://img.shields.io/jsdelivr/npm/hm/prettier-plugin-embed?cacheSeconds=300&color=ff5627)](https://www.jsdelivr.com/package/npm/prettier-plugin-embed)
 
-A Configurable [Prettier](https://prettier.io/) [Plugin](https://prettier.io/docs/en/plugins.html) to Format [Embedded Languages](https://prettier.io/docs/en/options.html#embedded-language-formatting) in `js`/`ts` Files.
+A configurable [Prettier](https://prettier.io/) [plugin](https://prettier.io/docs/en/plugins.html) to format [embedded languages](https://prettier.io/docs/en/options.html#embedded-language-formatting) in JS/TS Files.
 
 ```bash
 npm i -D prettier-plugin-embed
@@ -25,7 +25,7 @@ This Prettier plugin (namely [`prettier-plugin-embed`](https://github.com/Sec-an
 
 ### Why?
 
-Although Prettier has introduced the [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option for formatting embedded languages, it only supports two modes: `auto` and `off`. Therefore it doesn't allow for individual formatting adjustments for specific languages, nor does it support customizing the languages that require formatting and identifiers for identification. These limitations restrict the usability of this feature. For more detailed discussions, refer to: https://github.com/prettier/prettier/issues/4424 and https://github.com/prettier/prettier/issues/5588.
+Prettier has introduced an option for formatting embedded languages, named [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting). However, this option only offers two modes: `auto` and `off`. This limits its functionality, as it does not permit individual formatting adjustments for specific languages. Additionally, it lacks support for customizing which languages require formatting, as well as specifying block comments or tags for embedded language identification. These constraints hinder the feature's overall usability. For in-depth discussions on this matter, see the GitHub issues: [prettier/prettier#4424](https://github.com/prettier/prettier/issues/4424) and [prettier/prettier#5588](https://github.com/prettier/prettier/issues/5588).
 
 ### How?
 
@@ -35,15 +35,15 @@ By leveraging Prettier's plugin system, this plugin overrides the default [`embe
 
 - **Support for Additional Languages:** Extend the embedded language formatting capability to include languages such as XML, SQL, PHP, and more.
 
-- **Dual Identification Modes:** Identify embedded languages by tags `` identifier`...` `` or comments `` /* identifier */ `...` `` preceding the template literals.
+- **Dual Identification Modes:** Identify embedded languages by block comments `` /* comment */ `...` `` or tags `` tag`...` `` preceding the template literals.
 
-- **Customizable Language Identifiers:** Customize the identifiers used for identifying the embedded languages.
+- **Customizable Language Comments or Tags:** Customize the comments or tags used for identifying the embedded languages.
 
-- **Formatting Opt-out Mechanism:** Offer the capability to deactivate formatting for certain identifiers, including the default ones (`html`, `css`...) supported by the `embedded-language-formatting` option.
+- **Formatting Opt-out Mechanism:** Offer the capability to deactivate formatting for certain comments or tags, including the built-in ones (`html`, `css`...) supported by the `embedded-language-formatting` option.
 
 - **Configurable Formatting Style:** Provide additional options to tailor the formatting style for embedded languages.
 
-- **Strongly Typed API:** Benefit from comprehensive type support for configuring this plugin's options when employing the [Prettier API](https://prettier.io/docs/en/api) in TypeScript.
+- **Strongly Typed API:** Benefit from comprehensive type support for configuring this plugin's options.
 
 - **Easy Integration:** Integrate with the existing Prettier setup seamlessly, requiring minimal configuration to get started.
 
@@ -94,17 +94,17 @@ Here're some [quick start config examples](./ConfigExamples.md) to use this plug
 
 To use this plugin, [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option must be set to `auto` (which is the default setting as of now), because this option serves as the main switch for activating embedded language formatting.
 
-This plugin does not aim to implement parsers or printers to support every newly added embedded language. Instead, ideally, it makes use of existing [Prettier plugins](https://prettier.io/docs/en/plugins.html#official-plugins) for those languages and only adds formatting support when they are embedded in template literals.
+This plugin does not aim to implement parsers or printers to support every newly added embedded language. Rather, it aims to leverage existing [Prettier plugins](https://prettier.io/docs/en/plugins.html#official-plugins) for those languages, and only adds a thin layer of formatting support when they are embedded in template literals.
 
 Therefore, to enable formatting for a specific embedded language, the corresponding Prettier plugin for that language must also be loaded. For example, if you wish to format embedded XML language, you will need to load both this plugin and [`@prettier/plugin-xml`](https://github.com/prettier/plugin-xml). To find out which other plugins are required when using this plugin, please refer to the [Language-Specific Options](#language-specific-options) section below.
 
-Embedded languages to be formatted are required to be enclosed in the template literals, and are identified by the preceding [tags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) `` identifier`...` `` or [block comments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#block_comments) `` /* identifier */ `...` ``. This plugin comes pre-configured with a built-in set of identifiers for identifying various embedded languages. For instance, using identifiers like `xml` or `svg` will trigger automatic formatting for the embedded XML language. You can specify an alternative list of identifiers using the `embeddedXmlIdentifiers` option. The naming convention for these options follows the pattern of `embedded<Language>Identifiers` for other languages as well. Further details on these options and how to configure them are also available in the [Language-Specific Options](#language-specific-options) section.
+Embedded languages to be formatted are required to be enclosed in the template literals, and are identified by the preceding [block comments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#block_comments) `` /* comment */ `...` `` or [tags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) `` tag`...` ``. This plugin comes pre-configured with a built-in set of comments and tags for identifying various embedded languages. For instance, using comments like `/* xml */` or `/* svg */` or tags like `xml` or `svg` will trigger automatic formatting for the embedded XML language. You can specify an alternative list of comments or tags using the `embeddedXmlComments` option or the `embeddedXmlTags` option, respectively. The naming convention for these options follows the pattern of `embedded<Language>Comments` and `embedded<Language>Tags` for other languages as well. Further details on these options and how to configure them are also available in the [Language-Specific Options](#language-specific-options) section.
 
-To exclude certain identifiers from being identified, including the default ones supported by the [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option, add them to the list of the `embeddedNoopIdentifiers` option. Any matching identifiers listed in this option will take precedence over other `embedded<Language>Identifiers` options, effectively disabling their formatting.
+To exclude certain comments or tags from being identified, like the default ones supported by the [`embedded-language-formatting`](https://prettier.io/docs/en/options.html#embedded-language-formatting) option, add them to the list of the `embeddedNoopComments`/`embeddedNoopTags` options. Any matching comments or tags listed in these options will take precedence over other `embedded<Language>Comments` and `embedded<Language>Tags` options, effectively disabling their formatting.
 
 > [!IMPORTANT]
 >
-> Until this notice is removed, always specify identifiers explicitly and do not rely on the built-in defaults, as they may be subject to change.
+> Until this notice is removed, always specify comments or tags explicitly and do not rely on the built-in defaults, as they may be subject to change.
 
 ### Language-Specific Options
 
@@ -142,21 +142,59 @@ Click Here to Toggle
 
 #### NOOP
 
-##### `embeddedNoopIdentifiers`
+##### `embeddedNoopComments`
 
 - **Type**: `string[]`
 - **Default**: [`[]`](./src/embedded/noop/options.ts)
-- **Description**: Tag or comment identifiers that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.
+- **Description**: Block comments that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.
 
-This "language" doesn't require other plugins and can override the native embedded language formatting. It serves as a way to turn off embedded language formatting for the specified language identifiers.
+##### `embeddedNoopTags`
+
+- **Type**: `string[]`
+- **Default**: [`[]`](./src/embedded/noop/options.ts)
+- **Description**: Tags that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.
+
+##### ~~`embeddedNoopIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`[]`](./src/embedded/noop/options.ts)
+- **Description**: Comment or tag identifiers that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.
+
+Please use `embeddedNoopComments` or `embeddedNoopTags`.
+
+</details>
+
+This "language" doesn't require other plugins and can override the native embedded language formatting. It serves as a way to turn off embedded language formatting for the specified language comments or tags.
 
 #### CSS
 
-##### `embeddedCssIdentifiers`
+##### `embeddedCssComments`
 
 - **Type**: `string[]`
 - **Default**: [`["css"]`](./src/embedded/css/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded CSS language.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded CSS language.
+
+##### `embeddedCssTags`
+
+- **Type**: `string[]`
+- **Default**: [`["css"]`](./src/embedded/css/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded CSS language.
+
+##### ~~`embeddedCssIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["css"]`](./src/embedded/css/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded CSS language.
+
+Please use `embeddedCssComments` or `embeddedCssTags`.
+
+</details>
 
 ##### `embeddedCssParser`
 
@@ -166,17 +204,36 @@ This "language" doesn't require other plugins and can override the native embedd
 
 Formatting embedded CSS language doesn't require other plugins and uses the parsers and printers provided by Prettier natively.
 
-This can override the native formatting bahavior for embedded CSS language. If you want to keep the native behavior, set `embeddedCssIdentifiers` to `[]` or other identifiers.
+This can override the native formatting bahavior for embedded CSS language. If you want to keep the native behavior, set `embeddedCssComments` or `embeddedCssTags` to `[]` or other values.
 
-If you want to specify different parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+If you want to specify different parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### ES (ECMAScript/JavaScript)
 
-##### `embeddedEsIdentifiers`
+##### `embeddedEsComments`
 
 - **Type**: `string[]`
 - **Default**: [`["js", "jsx", "es", "es6", "mjs", "cjs", "pac", "javascript"]`](./src/embedded/es/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.
+
+##### `embeddedEsTags`
+
+- **Type**: `string[]`
+- **Default**: [`["js", "jsx", "es", "es6", "mjs", "cjs", "pac", "javascript"]`](./src/embedded/es/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.
+
+##### ~~`embeddedEsIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["js", "jsx", "es", "es6", "mjs", "cjs", "pac", "javascript"]`](./src/embedded/es/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.
+
+Please use `embeddedEsComments` or `embeddedEsTags`.
+
+</details>
 
 ##### `embeddedEsParser`
 
@@ -186,37 +243,94 @@ If you want to specify different parsers for different identifiers, check [`embe
 
 Formatting embedded ECMAScript/JavaScript language doesn't require other plugins and uses the parsers and printers provided by Prettier natively.
 
-If you want to specify different parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+If you want to specify different parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### GLSL
 
-##### `embeddedGlslIdentifiers`
+##### `embeddedGlslComments`
 
 - **Type**: `string[]`
 - **Default**: [`["glsl", "shader"]`](./src/embedded/glsl/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.
+
+##### `embeddedGlslTags`
+
+- **Type**: `string[]`
+- **Default**: [`["glsl", "shader"]`](./src/embedded/glsl/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.
+
+##### ~~`embeddedGlslIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["glsl", "shader"]`](./src/embedded/glsl/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.
+
+Please use `embeddedGlslComments` or `embeddedGlslTags`.
+
+</details>
 
 Formatting embedded GLSL language requires the [`prettier-plugin-glsl`](https://github.com/NaridaL/glsl-language-toolkit/tree/main/packages/prettier-plugin-glsl) plugin to be loaded as well.
 
 #### GraphQL
 
-##### `embeddedGraphqlIdentifiers`
+##### `embeddedGraphqlComments`
 
 - **Type**: `string[]`
 - **Default**: [`["graphql", "gql"]`](./src/embedded/graphql/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded GraphQL language.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded GraphQL language.
+
+##### `embeddedGraphqlTags`
+
+- **Type**: `string[]`
+- **Default**: [`["graphql", "gql"]`](./src/embedded/graphql/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded GraphQL language.
+
+##### ~~`embeddedGraphqlIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["graphql", "gql"]`](./src/embedded/graphql/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded GraphQL language.
+
+Please use `embeddedGraphqlComments` or `embeddedGraphqlTags`.
+
+</details>
 
 Formatting embedded GraphQL language doesn't require other plugins and uses the parsers and printers provided by Prettier natively.
 
-This can override the native formatting behavior for embedded GraphQL language. If you want to keep the native behavior, set `embeddedGraphqlIdentifiers` to `[]` or other identifiers.
+This can override the native formatting behavior for embedded GraphQL language. If you want to keep the native behavior, set `embeddedGraphqlComments` or `embeddedGraphqlTags` to `[]` or other values.
 
 #### HTML
 
-##### `embeddedHtmlIdentifiers`
+##### `embeddedHtmlComments`
 
 - **Type**: `string[]`
 - **Default**: [`["html", "xhtml"]`](./src/embedded/html/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded HTML language.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded HTML language.
+
+##### `embeddedHtmlTags`
+
+- **Type**: `string[]`
+- **Default**: [`["html", "xhtml"]`](./src/embedded/html/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded HTML language.
+
+##### ~~`embeddedHtmlIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["html", "xhtml"]`](./src/embedded/html/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded HTML language.
+
+Please use `embeddedHtmlComments` or `embeddedHtmlTags`.
+
+</details>
 
 ##### `embeddedHtmlParser`
 
@@ -226,37 +340,94 @@ This can override the native formatting behavior for embedded GraphQL language. 
 
 Formatting embedded HTML language doesn't require other plugins and uses the parsers and printers provided by Prettier natively.
 
-This can override the native formatting behavior for embedded HTML language. If you want to keep the native behavior, set `embeddedHtmlIdentifiers` to `[]` or other identifiers.
+This can override the native formatting behavior for embedded HTML language. If you want to keep the native behavior, set `embeddedHtmlComments` or `embeddedHtmlTags` to `[]` or other values.
 
-If you want to specify different parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+If you want to specify different parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### INI
 
-##### `embeddedIniIdentifiers`
+##### `embeddedIniComments`
 
 - **Type**: `string[]`
 - **Default**: [`["ini", "cfg", "pro"]`](./src/embedded/ini/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.
+
+##### `embeddedIniTags`
+
+- **Type**: `string[]`
+- **Default**: [`["ini", "cfg", "pro"]`](./src/embedded/ini/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.
+
+##### ~~`embeddedIniIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["ini", "cfg", "pro"]`](./src/embedded/ini/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.
+
+Please use `embeddedIniComments` or `embeddedIniTags`.
+
+</details>
 
 Formatting embedded INI language requires the [`prettier-plugin-ini`](https://github.com/kddnewton/prettier-plugin-ini) plugin to be loaded as well. And [options](https://github.com/kddnewton/prettier-plugin-ini#configuration) supported by `prettier-plugin-ini` can therefore be used to further control the formatting behavior.
 
 #### Java
 
-##### `embeddedJavaIdentifiers`
+##### `embeddedJavaComments`
 
 - **Type**: `string[]`
 - **Default**: [`["java"]`](./src/embedded/java/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.
+
+##### `embeddedJavaTags`
+
+- **Type**: `string[]`
+- **Default**: [`["java"]`](./src/embedded/java/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.
+
+##### ~~`embeddedJavaIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["java"]`](./src/embedded/java/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.
+
+Please use `embeddedJavaComments` or `embeddedJavaTags`.
+
+</details>
 
 Formatting embedded Java language requires the [`prettier-plugin-java`](https://github.com/jhipster/prettier-java/tree/main/packages/prettier-plugin-java) plugin to be loaded as well. And [options](https://github.com/jhipster/prettier-java/tree/main/packages/prettier-plugin-java#options) supported by `prettier-plugin-java` can therefore be used to further control the formatting behavior.
 
 #### JSON
 
-##### `embeddedJsonIdentifiers`
+##### `embeddedJsonComments`
 
 - **Type**: `string[]`
 - **Default**: [`["json", "jsonl"]`](./src/embedded/json/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded JSON language.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded JSON language.
+
+##### `embeddedJsonTags`
+
+- **Type**: `string[]`
+- **Default**: [`["json", "jsonl"]`](./src/embedded/json/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded JSON language.
+
+##### ~~`embeddedJsonIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["json", "jsonl"]`](./src/embedded/json/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded JSON language.
+
+Please use `embeddedJsonComments` or `embeddedJsonTags`.
+
+</details>
 
 ##### `embeddedJsonParser`
 
@@ -266,35 +437,92 @@ Formatting embedded Java language requires the [`prettier-plugin-java`](https://
 
 Formatting embedded JSON language doesn't require other plugins and uses the parsers and printers provided by Prettier natively.
 
-If you want to specify different parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+If you want to specify different parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### JSONata
 
-##### `embeddedJsonataIdentifiers`
+##### `embeddedJsonataComments`
 
 - **Type**: `string[]`
 - **Default**: [`["jsonata"]`](./src/embedded/jsonata/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.
+
+##### `embeddedJsonataTags`
+
+- **Type**: `string[]`
+- **Default**: [`["jsonata"]`](./src/embedded/jsonata/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.
+
+##### ~~`embeddedJsonataIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["jsonata"]`](./src/embedded/jsonata/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.
+
+Please use `embeddedJsonataComments` or `embeddedJsonataTags`.
+
+</details>
 
 Formatting embedded JSONata language requires the [`@stedi/prettier-plugin-jsonata`](https://github.com/Stedi/prettier-plugin-jsonata) plugin to be loaded as well.
 
 #### LaTeX
 
-##### `embeddedLatexIdentifiers`
+##### `embeddedLatexComments`
 
 - **Type**: `string[]`
 - **Default**: [`["latex", "tex", "aux", "cls", "bbl", "bib", "toc", "sty"]`](./src/embedded/latex/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.
+
+##### `embeddedLatexTags`
+
+- **Type**: `string[]`
+- **Default**: [`["latex", "tex", "aux", "cls", "bbl", "bib", "toc", "sty"]`](./src/embedded/latex/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.
+
+##### ~~`embeddedLatexIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["latex", "tex", "aux", "cls", "bbl", "bib", "toc", "sty"]`](./src/embedded/latex/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.
+
+Please use `embeddedLatexComments` or `embeddedLatexTags`.
+
+</details>
 
 Formatting embedded LaTeX language requires the [`prettier-plugin-latex`](https://github.com/siefkenj/prettier-plugin-latex) plugin to be loaded as well.
 
 #### Markdown
 
-##### `embeddedMarkdownIdentifiers`
+##### `embeddedMarkdownComments`
 
 - **Type**: `string[]`
 - **Default**: [`["md", "markdown"]`](./src/embedded/markdown/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded Markdown language.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded Markdown language.
+
+##### `embeddedMarkdownTags`
+
+- **Type**: `string[]`
+- **Default**: [`["md", "markdown"]`](./src/embedded/markdown/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded Markdown language.
+
+##### ~~`embeddedMarkdownIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["md", "markdown"]`](./src/embedded/markdown/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded Markdown language.
+
+Please use `embeddedMarkdownComments` or `embeddedMarkdownTags`.
+
+</details>
 
 ##### `embeddedMarkdownParser`
 
@@ -304,81 +532,214 @@ Formatting embedded LaTeX language requires the [`prettier-plugin-latex`](https:
 
 Formatting embedded Markdown language doesn't require other plugins and uses the parsers and printers provided by Prettier natively.
 
-This can override the native formatting for embedded Markdown language. If you want to keep the native behavior, set `embeddedMarkdownIdentifiers` to `[]` or other identifiers.
+This can override the native formatting for embedded Markdown language. If you want to keep the native behavior, set `embeddedMarkdownComments` or `embeddedMarkdownTags` to `[]` or other values.
 
-If you want to specify different parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+If you want to specify different parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 The `remark` parser is [an alias of the `markdown` parser](https://github.com/prettier/prettier/blob/ed23dacc9e655c3876971b30859497b17ff2cf9f/src/language-markdown/parser-markdown.js#L57).
 
 #### NGINX
 
-##### `embeddedNginxIdentifiers`
+##### `embeddedNginxComments`
 
 - **Type**: `string[]`
 - **Default**: [`["nginx"]`](./src/embedded/nginx/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.
+
+##### `embeddedNginxTags`
+
+- **Type**: `string[]`
+- **Default**: [`["nginx"]`](./src/embedded/nginx/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.
+
+##### ~~`embeddedNginxIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["nginx"]`](./src/embedded/nginx/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.
+
+Please use `embeddedNginxComments` or `embeddedNginxTags`.
+
+</details>
 
 Formatting embedded NGINX language requires the [`prettier-plugin-nginx`](https://github.com/jxddk/prettier-plugin-nginx) plugin to be loaded as well. And [options](https://github.com/jxddk/prettier-plugin-nginx?tab=readme-ov-file#configuration) supported by `prettier-plugin-nginx` can therefore be used to further control the formatting behavior.
 
 #### Pegjs
 
-##### `embeddedPegjsIdentifiers`
+##### `embeddedPegjsComments`
 
 - **Type**: `string[]`
 - **Default**: [`["pegjs", "peggy", "peg"]`](./src/embedded/pegjs/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.
+
+##### `embeddedPegjsTags`
+
+- **Type**: `string[]`
+- **Default**: [`["pegjs", "peggy", "peg"]`](./src/embedded/pegjs/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.
+
+##### ~~`embeddedPegjsIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["pegjs", "peggy", "peg"]`](./src/embedded/pegjs/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.
+
+Please use `embeddedPegjsComments` or `embeddedPegjsTags`.
+
+</details>
 
 Formatting embedded Pegjs language requires the [`prettier-plugin-pegjs`](https://github.com/siefkenj/prettier-plugin-pegjs) plugin to be loaded as well. And [options](https://github.com/siefkenj/prettier-plugin-pegjs?tab=readme-ov-file#options) supported by `prettier-plugin-pegjs` can therefore be used to further control the formatting behavior.
 
-Note that `prettier-plugin-pegjs` supports different parsers for the action blocks and they are specified by the [`actionParser` option](https://github.com/siefkenj/prettier-plugin-pegjs?tab=readme-ov-file#options). If you want to specify different action parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+Note that `prettier-plugin-pegjs` supports different parsers for the action blocks and they are specified by the [`actionParser` option](https://github.com/siefkenj/prettier-plugin-pegjs?tab=readme-ov-file#options). If you want to specify different action parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### PHP
 
-##### `embeddedPhpIdentifiers`
+##### `embeddedPhpComments`
 
 - **Type**: `string[]`
 - **Default**: [`["php", "php5"]`](./src/embedded/php/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.
+
+##### `embeddedPhpTags`
+
+- **Type**: `string[]`
+- **Default**: [`["php", "php5"]`](./src/embedded/php/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.
+
+##### ~~`embeddedPhpIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["php", "php5"]`](./src/embedded/php/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.
+
+Please use `embeddedPhpComments` or `embeddedPhpTags`.
+
+</details>
 
 Formatting embedded PHP language requires the [`@prettier/plugin-php`](https://github.com/prettier/plugin-php) plugin to be loaded as well. And [options](https://github.com/prettier/plugin-php#configuration) supported by `@prettier/plugin-php` can therefore be used to further control the formatting behavior.
 
 #### Prisma
 
-##### `embeddedPrismaIdentifiers`
+##### `embeddedPrismaComments`
 
 - **Type**: `string[]`
 - **Default**: [`["prisma"]`](./src/embedded/prisma/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.
+
+##### `embeddedPrismaTags`
+
+- **Type**: `string[]`
+- **Default**: [`["prisma"]`](./src/embedded/prisma/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.
+
+##### ~~`embeddedPrismaIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["prisma"]`](./src/embedded/prisma/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.
+
+Please use `embeddedPrismaComments` or `embeddedPrismaTags`.
+
+</details>
 
 Formatting embedded Prisma language requires the [`prettier-plugin-prisma`](https://github.com/avocadowastaken/prettier-plugin-prisma) plugin to be loaded as well.
 
 #### Properties
 
-##### `embeddedPropertiesIdentifiers`
+##### `embeddedPropertiesComments`
 
 - **Type**: `string[]`
 - **Default**: [`["properties"]`](./src/embedded/properties/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.
+
+##### `embeddedPropertiesTags`
+
+- **Type**: `string[]`
+- **Default**: [`["properties"]`](./src/embedded/properties/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.
+
+##### ~~`embeddedPropertiesIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["properties"]`](./src/embedded/properties/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.
+
+Please use `embeddedPropertiesComments` or `embeddedPropertiesTags`.
+
+</details>
 
 Formatting embedded Properties language requires the [`prettier-plugin-properties`](https://github.com/eemeli/prettier-plugin-properties) plugin to be loaded as well. And [options](https://github.com/eemeli/prettier-plugin-properties#configuration) supported by `prettier-plugin-properties` can therefore be used to further control the formatting behavior.
 
 #### Pug
 
-##### `embeddedPugIdentifiers`
+##### `embeddedPugComments`
 
 - **Type**: `string[]`
 - **Default**: [`["pug", "jade"]`](./src/embedded/pug/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.
+
+##### `embeddedPugTags`
+
+- **Type**: `string[]`
+- **Default**: [`["pug", "jade"]`](./src/embedded/pug/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.
+
+##### ~~`embeddedPugIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["pug", "jade"]`](./src/embedded/pug/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.
+
+Please use `embeddedPugComments` or `embeddedPugTags`.
+
+</details>
 
 Formatting embedded Pug language requires the [`@prettier/plugin-pug`](https://github.com/prettier/plugin-pug) plugin to be loaded as well. And [options](https://github.com/prettier/plugin-pug?tab=readme-ov-file#configuration) supported by `@prettier/plugin-pug` can therefore be used to further control the formatting behavior.
 
 #### Ruby
 
-##### `embeddedRubyIdentifiers`
+##### `embeddedRubyComments`
 
 - **Type**: `string[]`
 - **Default**: [`["ruby"]`](./src/embedded/ruby/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.
+
+##### `embeddedRubyTags`
+
+- **Type**: `string[]`
+- **Default**: [`["ruby"]`](./src/embedded/ruby/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.
+
+##### ~~`embeddedRubyIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["ruby"]`](./src/embedded/ruby/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.
+
+Please use `embeddedRubyComments` or `embeddedRubyTags`.
+
+</details>
 
 ##### `embeddedRubyParser`
 
@@ -388,27 +749,65 @@ Formatting embedded Pug language requires the [`@prettier/plugin-pug`](https://g
 
 Formatting embedded Ruby language requires the [`@prettier/plugin-ruby`](https://github.com/prettier/plugin-ruby) to be loaded and [its dependencies to be installed](https://github.com/prettier/plugin-ruby#getting-started) as well. And [options](https://github.com/prettier/plugin-ruby#configuration) supported by `@prettier/plugin-ruby` can therefore be used to further control the formatting behavior.
 
-If you want to specify different parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+If you want to specify different parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### Sh (Shell)
 
-##### `embeddedShIdentifiers`
+##### `embeddedShComments`
 
 - **Type**: `string[]`
 - **Default**: [`["sh"]`](./src/embedded/sh/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.
+
+##### `embeddedShTags`
+
+- **Type**: `string[]`
+- **Default**: [`["sh"]`](./src/embedded/sh/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.
+
+##### ~~`embeddedShIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["sh"]`](./src/embedded/sh/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.
+
+Please use `embeddedShComments` or `embeddedShTags`.
+
+</details>
 
 Formatting embedded Shell language requires the [`prettier-plugin-sh`](https://github.com/un-ts/prettier/tree/master/packages/sh#readme) plugin to be loaded as well. And [options](https://github.com/un-ts/prettier/tree/master/packages/sh#parser-options) supported by `prettier-plugin-sh` can therefore be used to further control the formatting behavior.
 
-Note that `prettier-plugin-sh` supports different variants of shell syntaxes and they are specified by the [`variant` option](https://github.com/un-ts/prettier/tree/master/packages/sh#parser-options). If you want to specify different variants for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+Note that `prettier-plugin-sh` supports different variants of shell syntaxes and they are specified by the [`variant` option](https://github.com/un-ts/prettier/tree/master/packages/sh#parser-options). If you want to specify different variants for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### SQL
 
-##### `embeddedSqlIdentifiers`
+##### `embeddedSqlComments`
 
 - **Type**: `string[]`
 - **Default**: [`["sql"]`](./src/embedded/sql/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.
+
+##### `embeddedSqlTags`
+
+- **Type**: `string[]`
+- **Default**: [`["sql"]`](./src/embedded/sql/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.
+
+##### ~~`embeddedSqlIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["sql"]`](./src/embedded/sql/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.
+
+Please use `embeddedSqlComments` or `embeddedSqlTags`.
+
+</details>
 
 ##### `embeddedSqlPlugin`
 
@@ -424,25 +823,63 @@ Note that `prettier-plugin-sh` supports different variants of shell syntaxes and
 
 Formatting embedded SQL language requires the [`prettier-plugin-sql`](https://github.com/un-ts/prettier/tree/master/packages/sql#readme) plugin or the [`prettier-plugin-sql-cst`](https://github.com/nene/prettier-plugin-sql-cst) plugin to be loaded as well. And [options](https://github.com/un-ts/prettier/tree/master/packages/sql#parser-options) supported by `prettier-plugin-sql`, or [options](https://github.com/nene/prettier-plugin-sql-cst?tab=readme-ov-file#configuration) supported by `prettier-plugin-sql-cst` can therefore be used to further control the formatting behavior.
 
-Note that `prettier-plugin-sql` supports many different SQL dialects which are specified by the [`language`, `database` or `dialect` option](https://github.com/un-ts/prettier/tree/master/packages/sql#parser-options). And `prettier-plugin-sql-cst` also supports various parsers as shown above. If you want to specify different dialects or parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+Note that `prettier-plugin-sql` supports many different SQL dialects which are specified by the [`language`, `database` or `dialect` option](https://github.com/un-ts/prettier/tree/master/packages/sql#parser-options). And `prettier-plugin-sql-cst` also supports various parsers as shown above. If you want to specify different dialects or parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### TOML
 
-##### `embeddedTomlIdentifiers`
+##### `embeddedTomlComments`
 
 - **Type**: `string[]`
 - **Default**: [`["toml"]`](./src/embedded/toml/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.
+
+##### `embeddedTomlTags`
+
+- **Type**: `string[]`
+- **Default**: [`["toml"]`](./src/embedded/toml/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.
+
+##### ~~`embeddedTomlIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["toml"]`](./src/embedded/toml/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.
+
+Please use `embeddedTomlComments` or `embeddedTomlTags`.
+
+</details>
 
 Formatting embedded TOML language requires the [`prettier-plugin-toml`](https://github.com/un-ts/prettier/tree/master/packages/toml#readme) plugin to be loaded as well. And [options](https://github.com/un-ts/prettier/blob/master/packages/toml/src/options.ts) supported by `prettier-plugin-toml` can therefore be used to further control the formatting behavior.
 
 #### TS (TypeScript)
 
-##### `embeddedTsIdentifiers`
+##### `embeddedTsComments`
 
 - **Type**: `string[]`
 - **Default**: [`["ts", "tsx", "cts", "mts", "typescript"]`](./src/embedded/ts/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded TypeScript language.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded TypeScript language.
+
+##### `embeddedTsTags`
+
+- **Type**: `string[]`
+- **Default**: [`["ts", "tsx", "cts", "mts", "typescript"]`](./src/embedded/ts/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded TypeScript language.
+
+##### ~~`embeddedTsIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["ts", "tsx", "cts", "mts", "typescript"]`](./src/embedded/ts/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded TypeScript language.
+
+Please use `embeddedTsComments` or `embeddedTsTags`.
+
+</details>
 
 ##### `embeddedTsParser`
 
@@ -452,25 +889,63 @@ Formatting embedded TOML language requires the [`prettier-plugin-toml`](https://
 
 Formatting embedded TypeScript language doesn't require other plugins and uses the parsers and printers provided by Prettier natively.
 
-If you want to specify different parsers for different identifiers, check [`embeddedOverrides`](#embeddedoverrides-1).
+If you want to specify different parsers for different comments or tags, check [`embeddedOverrides`](#embeddedoverrides-1).
 
 #### XML
 
-##### `embeddedXmlIdentifiers`
+##### `embeddedXmlComments`
 
 - **Type**: `string[]`
 - **Default**: [`["xml", "opml", "rss", "svg"]`](./src/embedded/xml/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.
+
+##### `embeddedXmlTags`
+
+- **Type**: `string[]`
+- **Default**: [`["xml", "opml", "rss", "svg"]`](./src/embedded/xml/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.
+
+##### ~~`embeddedXmlIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["xml", "opml", "rss", "svg"]`](./src/embedded/xml/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.
+
+Please use `embeddedXmlComments` or `embeddedXmlTags`.
+
+</details>
 
 Formatting embedded XML language requires the [`@prettier/plugin-xml`](https://github.com/prettier/plugin-xml) plugin to be loaded as well. And [options](https://github.com/prettier/plugin-xml#configuration) supported by `@prettier/plugin-xml` can therefore be used to further control the formatting behavior.
 
 #### YAML
 
-##### `embeddedYamlIdentifiers`
+##### `embeddedYamlComments`
 
 - **Type**: `string[]`
 - **Default**: [`["yaml", "yml"]`](./src/embedded/yaml/options.ts)
-- **Description**: Tag or comment identifiers that make their subsequent template literals be identified as embedded YAML language.
+- **Description**: Block comments that make their subsequent template literals be identified as embedded YAML language.
+
+##### `embeddedYamlTags`
+
+- **Type**: `string[]`
+- **Default**: [`["yaml", "yml"]`](./src/embedded/yaml/options.ts)
+- **Description**: Tags that make their subsequent template literals be identified as embedded YAML language.
+
+##### ~~`embeddedYamlIdentifiers`~~
+
+<details>
+<summary>deprecated</summary>
+
+- **Type**: `string[]`
+- **Default**: [`["yaml", "yml"]`](./src/embedded/yaml/options.ts)
+- **Description**: Comment or tag identifiers that make their subsequent template literals be identified as embedded YAML language.
+
+Please use `embeddedYamlComments` or `embeddedYamlTags`.
+
+</details>
 
 Formatting embedded YAML language doesn't require other plugins and uses the parsers and printers provided by Prettier natively.
 
@@ -480,45 +955,59 @@ Formatting embedded YAML language doesn't require other plugins and uses the par
 
 #### Language-Agnostic
 
-##### `noEmbeddedIdentificationByComment`
+##### ~~`noEmbeddedIdentificationByComment`~~
+
+<details>
+<summary>deprecated</summary>
 
 - **Type**: `string[]`
 - **Default**: `[]`
-- **Description**: Turns off `` /* identifier */ `...` `` comment-based embedded language identification for the specified identifiers.
+- **Description**: Turns off `` /* comment */ `...` `` comment-based embedded language identification for the specified identifiers.
 
-##### `noEmbeddedIdentificationByTag`
+Please use `embedded<Language>Comments` or `embedded<Language>Tags` to configure each embedded language, and you won't need this option anymore.
+
+</details>
+
+##### ~~`noEmbeddedIdentificationByTag`~~
+
+<details>
+<summary>deprecated</summary>
 
 - **Type**: `string[]`
 - **Default**: `[]`
-- **Description**: Turns off `` identifier`...` `` tag-based embedded language identification for the specified identifiers.
+- **Description**: Turns off `` tag`...` `` tag-based embedded language identification for the specified identifiers.
+
+Please use `embedded<Language>Comments` or `embedded<Language>Tags` to configure each embedded language, and you won't need this option anymore.
+
+</details>
 
 ##### `preserveEmbeddedExteriorWhitespaces`
 
 - **Type**: `string[]`
 - **Default**: `[]`
-- **Description**: Preserves leading and trailing whitespaces in the formatting results for the specified identifiers.
+- **Description**: Preserves leading and trailing whitespaces in the formatting results for the specified comments or tags.
 
 ##### `noEmbeddedMultiLineIndentation`
 
 - **Type**: `string[]`
 - **Default**: `[]`
-- **Description**: Turns off auto indentation in the formatting results when they are formatted to span multi lines for the specified identifiers.
+- **Description**: Turns off auto indentation in the formatting results for the specified comments or tags when they are formatted to span multi lines.
 
 ##### `embeddedOverrides`
 
 - **Type**: `string`
 - **Default**: `undefined`
-- **Description**: Option overrides for the specified identifiers. It should either be a stringified JSON or an absolute filepath to the option overrides file. See [below](#embeddedoverrides-1) for a detailed explanation.
+- **Description**: Option overrides for the specified comments or tags. It should either be a stringified JSON or an absolute filepath to the option overrides file. See [below](#embeddedoverrides-1) for a detailed explanation.
 
 #### `embeddedOverrides`
 
-This option is provided for users to override certain options based on identifiers. Due to the lack of support for using objects in prettier plugin options (https://github.com/prettier/prettier/issues/14671), it accepts a **stringified** json string, or a file path with an extension of `.json`, `.jsonc`, `.js`, `.cjs`, `.mjs`, `.ts`, `.cts` or `.mts` as its value. If no extension is provided, it will be treated as a `.json`/`.jsonc` file. For relative paths, it will automatically figure out the prettier config location and use that as the base path.
+This option is provided for users to override certain options based on comments or tags. Due to the lack of support for using objects in prettier plugin options (https://github.com/prettier/prettier/issues/14671), it accepts a **stringified** json string, or a file path with an extension of `.json`, `.jsonc`, `.js`, `.cjs`, `.mjs`, `.ts`, `.cts` or `.mts` as its value. If no extension is provided, it will be treated as a `.json`/`.jsonc` file. For relative paths, it will automatically figure out the prettier config location and use that as the base path.
 
 > [!NOTE]
 >
 > The support for using `.ts`, `.mts` or `.cts` files for `embeddedOverrides` requires a minimal `node` version of [18.19.0](https://nodejs.org/en/blog/release/v18.19.0#esm-and-customization-hook-changes), and [`tsx`](https://github.com/privatenumber/tsx) as a dependency in your project. And it currently doesn't work with the Prettier VSCode extension.
 
-The resolved value should be an array of objects. Each object in the array must have 2 fields: `identifiers` and `options`. The `options` are considerred overrides that will be applied to the global `options` of prettier for those `idenfitiers` only. It's like the [`overrides`](https://prettier.io/docs/en/configuration.html#configuration-overrides) of `prettier`, but it is identifier-based instead of file-based.
+The resolved value should be an array of objects. Each object in the array must have 2 fields: `comments` and `options`, or `tags` and `options`. The `options` are considerred overrides that will be applied to the global `options` of prettier for those `comments` and `tags` only. It's like the [`overrides`](https://prettier.io/docs/en/configuration.html#configuration-overrides) of `prettier`, but it is comment/tag-based instead of file-based.
 
 In a json file, the root is the array of objects. In a JavaScript/TypeScript file, the array of objects should be a default export, or a named export with the name `embeddedOverrides`.
 
@@ -527,13 +1016,13 @@ An example `.json`/`.jsonc` file is:
 ```json
 [
   {
-    "identifiers": ["sql"],
+    "comments": ["sql"],
     "options": {
       "keywordCase": "lower"
     }
   },
   {
-    "identifiers": ["mysql"],
+    "tags": ["mysql"],
     "options": {
       "keywordCase": "upper"
     }
@@ -543,7 +1032,7 @@ An example `.json`/`.jsonc` file is:
 
 > [!CAUTION]
 >
-> Please note that not every option is supported to override. That largely depends on at which phase those options will kick in and take effect. For example, you can't override `tabWidth` in `embeddedOverrides` because this option is used in the [`printDocToString`](https://github.com/prettier/prettier/blob/7aecca5d6473d73f562ca3af874831315f8f2581/src/document/printer.js#L302) phase, where `prettier-plugin-embed` cannot override this option for only a set of specified identifiers. To find the list of unsupported options, please check the interface definition of `EmbeddedOverride` in the [source code](https://github.com/Sec-ant/prettier-plugin-embed/blob/main/src/types.ts).
+> Please note that not every option is supported to override. That largely depends on at which phase those options will kick in and take effect. For example, you can't override `tabWidth` in `embeddedOverrides` because this option is used in the [`printDocToString`](https://github.com/prettier/prettier/blob/7aecca5d6473d73f562ca3af874831315f8f2581/src/document/printer.js#L302) phase, where `prettier-plugin-embed` cannot override this option for only a set of specified comments or tags. To find the list of unsupported options, please check the interface definition of `EmbeddedOverride` in the [source code](https://github.com/Sec-ant/prettier-plugin-embed/blob/main/src/types.ts).
 
 ### Typed Options
 
@@ -598,7 +1087,7 @@ There're several ways to use the typed options provided by this plugin. Taking t
    * @type {import("prettier-plugin-embed").PluginEmbedOptions}
    */
   const pluginEmbedOptions = {
-    embeddedSqlIdentifiers: ["sql"],
+    embeddedSqlTags: ["sql"],
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-embed",
-  "description": "A configurable Prettier plugin to format embedded languages in js/ts files.",
+  "description": "A configurable Prettier plugin to format embedded languages in JS/TS files.",
   "private": false,
   "version": "0.4.10",
   "type": "module",

--- a/src/embedded/css/embedder.ts
+++ b/src/embedded/css/embedder.ts
@@ -15,7 +15,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -52,14 +52,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -72,7 +72,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/css/options.ts
+++ b/src/embedded/css/options.ts
@@ -2,29 +2,30 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/microsoft/vscode/blob/de0121cf0e05d1673903551b6dbb2871556bfae9/extensions/css/package.json#L22
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L887
- */
-const DEFAULT_IDENTIFIERS = ["css"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["css"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const CSS_PARSERS = ["css", "less", "scss"] as const;
-
 type CssParser = (typeof CSS_PARSERS)[number];
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
 
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
 
 export const options = {
@@ -32,9 +33,26 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded CSS language.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded CSS language.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded CSS language.",
   },
   [EMBEDDED_LANGUAGE_PARSER]: {
     category: "Embed",
@@ -52,9 +70,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedCssComments` or `embeddedCssTags`.,
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     [EMBEDDED_LANGUAGE_PARSER]?: CssParser;
   }
 }

--- a/src/embedded/es/embedder.ts
+++ b/src/embedded/es/embedder.ts
@@ -15,7 +15,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -52,14 +52,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -72,7 +72,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/es/options.ts
+++ b/src/embedded/es/options.ts
@@ -2,18 +2,14 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/microsoft/vscode/blob/de0121cf0e05d1673903551b6dbb2871556bfae9/extensions/javascript/package.json#L37
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L3314
- */
-const DEFAULT_IDENTIFIERS = [
+const DEFAULT_COMMENTS_OR_TAGS = [
   "js",
   "jsx",
   "es",
@@ -24,10 +20,13 @@ const DEFAULT_IDENTIFIERS = [
   "javascript",
 ] as const;
 
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 // TODO: keep in sync with prettier somehow
 const ES_PARSERS = [
@@ -38,11 +37,12 @@ const ES_PARSERS = [
   "flow",
   "meriyah",
 ] as const;
-
 export type EsParser = (typeof ES_PARSERS)[number];
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
 
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
 
 export const options = {
@@ -50,9 +50,26 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.",
   },
   [EMBEDDED_LANGUAGE_PARSER]: {
     category: "Embed",
@@ -71,9 +88,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedEsComments` or `embeddedEsTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     [EMBEDDED_LANGUAGE_PARSER]?: EsParser;
   }
 }

--- a/src/embedded/glsl/embedder.ts
+++ b/src/embedded/glsl/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-glsl", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-glsl", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/glsl/options.ts
+++ b/src/embedded/glsl/options.ts
@@ -2,32 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/NaridaL/glsl-language-toolkit/blob/a7bd08d3f31355b335ae002b6a44c2999998b952/packages/prettier-plugin-glsl/src/prettier-plugin.ts#L88
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L2180
- */
-const DEFAULT_IDENTIFIERS = ["glsl", "shader"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["glsl", "shader"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -35,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedGlslComments` or `embeddedGlslTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/graphql/embedder.ts
+++ b/src/embedded/graphql/embedder.ts
@@ -15,7 +15,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -52,14 +52,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -72,7 +72,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/graphql/options.ts
+++ b/src/embedded/graphql/options.ts
@@ -2,31 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L2578
- */
-const DEFAULT_IDENTIFIERS = ["graphql", "gql"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["graphql", "gql"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded GraphQL language.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded GraphQL language.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded GraphQL language.",
   },
 } as const satisfies SupportOptions;
 
@@ -34,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedGraphqlComments` or `embeddedGraphqlTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/html/embedder.ts
+++ b/src/embedded/html/embedder.ts
@@ -12,7 +12,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -75,14 +75,14 @@ export const embedder: Embedder<Options> = async (
     resolvedOptions.htmlWhitespaceSensitivity === "strict" ||
     // TODO: is css mode should be included here?
     resolvedOptions.htmlWhitespaceSensitivity === "css" ||
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -95,7 +95,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/html/options.ts
+++ b/src/embedded/html/options.ts
@@ -2,29 +2,30 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References
- *
- * - https://github.com/microsoft/vscode/blob/de0121cf0e05d1673903551b6dbb2871556bfae9/extensions/html/package.json#L18
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L2684
- */
-const DEFAULT_IDENTIFIERS = ["html", "xhtml"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["html", "xhtml"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const HTML_PARSERS = ["html", "vue", "angular", "lwc"] as const;
-
 type HtmlParser = (typeof HTML_PARSERS)[number];
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
 
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
 
 export const options = {
@@ -32,9 +33,26 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded HTML language.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded HTML language.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded HTML language.",
   },
   [EMBEDDED_LANGUAGE_PARSER]: {
     category: "Embed",
@@ -52,9 +70,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedHtmlComments` or `embeddedHtmlTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     [EMBEDDED_LANGUAGE_PARSER]?: HtmlParser;
   }
 }

--- a/src/embedded/index.ts
+++ b/src/embedded/index.ts
@@ -1,13 +1,18 @@
 export * from "./register.js";
 export type {
-  EmbeddedDefaultIdentifier,
+  EmbeddedDefaultComment,
+  EmbeddedDefaultTag,
   EmbeddedEmbedders,
   EmbeddedLanguage,
   EmbeddedOptions,
   EmbeddedParsers,
+  EmbeddedComment,
+  EmbeddedTag,
   PluginEmbedOptions,
 } from "./types.js";
 export {
   makeIdentifiersOptionName,
+  makeCommentsOptionName,
+  makeTagsOptionName,
   type AutocompleteStringList,
 } from "./utils.js";

--- a/src/embedded/ini/embedder.ts
+++ b/src/embedded/ini/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-ini", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-ini", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/ini/options.ts
+++ b/src/embedded/ini/options.ts
@@ -2,31 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L2928
- */
-const DEFAULT_IDENTIFIERS = ["ini", "cfg", "pro"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["ini", "cfg", "pro"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -34,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedIniComments` or `embeddedIniTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/java/embedder.ts
+++ b/src/embedded/java/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-java", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-java", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -60,14 +60,14 @@ export const embedder: Embedder<Options> = async (
   );
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -80,7 +80,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/java/options.ts
+++ b/src/embedded/java/options.ts
@@ -2,26 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-const DEFAULT_IDENTIFIERS = ["java"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["java"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -29,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedJavaComments` or `embeddedJavaTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/json/embedder.ts
+++ b/src/embedded/json/embedder.ts
@@ -15,7 +15,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -52,14 +52,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -72,7 +72,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/json/options.ts
+++ b/src/embedded/json/options.ts
@@ -2,39 +2,58 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L3141
- */
-const DEFAULT_IDENTIFIERS = ["json", "jsonl"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["json", "jsonl"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 // TODO: keep in sync with prettier somehow
 const JSON_PARSERS = ["json", "json5", "jsonc", "json-stringify"] as const;
-
 type JsonParser = (typeof JSON_PARSERS)[number];
 
-const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
-
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
+const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded JSON language.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded JSON language.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded JSON language.",
   },
   [EMBEDDED_LANGUAGE_PARSER]: {
     category: "Embed",
@@ -52,9 +71,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedJsonComments` or `embeddedJsonTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     [EMBEDDED_LANGUAGE_PARSER]?: JsonParser;
   }
 }

--- a/src/embedded/jsonata/embedder.ts
+++ b/src/embedded/jsonata/embedder.ts
@@ -16,12 +16,12 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   throwIfPluginIsNotFound(
     "@stedi/prettier-plugin-jsonata",
     options,
-    identifier,
+    commentOrTag,
   );
 
   const resolvedOptions = {
@@ -59,14 +59,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -79,7 +79,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/jsonata/options.ts
+++ b/src/embedded/jsonata/options.ts
@@ -2,26 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-const DEFAULT_IDENTIFIERS = ["jsonata"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["jsonata"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -29,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedJsonataComments` or `embeddedJsonataTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/latex/embedder.ts
+++ b/src/embedded/latex/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-latex", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-latex", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/latex/options.ts
+++ b/src/embedded/latex/options.ts
@@ -2,16 +2,13 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L6994
- */
-const DEFAULT_IDENTIFIERS = [
+const DEFAULT_COMMENTS_OR_TAGS = [
   "latex",
   "tex",
   "aux",
@@ -21,21 +18,45 @@ const DEFAULT_IDENTIFIERS = [
   "toc",
   "sty",
 ] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -43,8 +64,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedLatexComments` or `embeddedLatexTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/markdown/embedder.ts
+++ b/src/embedded/markdown/embedder.ts
@@ -15,7 +15,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -53,14 +53,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -73,7 +73,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/markdown/options.ts
+++ b/src/embedded/markdown/options.ts
@@ -2,29 +2,30 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/microsoft/vscode/blob/de0121cf0e05d1673903551b6dbb2871556bfae9/extensions/markdown-basics/package.json#L19
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L4060
- */
-const DEFAULT_IDENTIFIERS = ["md", "markdown"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["md", "markdown"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const MARKDOWN_PARSERS = ["markdown", "mdx", "remark"] as const;
-
 type MarkdownParser = (typeof MARKDOWN_PARSERS)[number];
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
 
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
 
 export const options = {
@@ -32,9 +33,26 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded Markdown language.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded Markdown language.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded Markdown language.",
   },
   [EMBEDDED_LANGUAGE_PARSER]: {
     category: "Embed",
@@ -52,9 +70,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedMarkdownComments` or `embeddedMarkdownTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     [EMBEDDED_LANGUAGE_PARSER]?: MarkdownParser;
   }
 }

--- a/src/embedded/nginx/embedder.ts
+++ b/src/embedded/nginx/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-nginx", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-nginx", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/nginx/options.ts
+++ b/src/embedded/nginx/options.ts
@@ -2,26 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-const DEFAULT_IDENTIFIERS = ["nginx"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["nginx"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -29,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedNginxComments` or `embeddedNginxTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/noop/options.ts
+++ b/src/embedded/noop/options.ts
@@ -1,14 +1,21 @@
 import type { SupportOptions } from "prettier";
-import type { EmbeddedDefaultIdentifier } from "../types.js";
+import type { EmbeddedDefaultComment, EmbeddedDefaultTag } from "../types.js";
 import {
   type AutocompleteStringList,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-type EmbeddedIdentifiers = AutocompleteStringList<EmbeddedDefaultIdentifier>;
+type EmbeddedCommentsOrTags = AutocompleteStringList<
+  EmbeddedDefaultComment | EmbeddedDefaultTag
+>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
@@ -18,6 +25,23 @@ export const options = {
     default: [{ value: [] }],
     description:
       "Tag or comment identifiers that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.",
   },
 } as const satisfies SupportOptions;
 
@@ -26,6 +50,11 @@ type Options = typeof options;
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: EmbeddedIdentifiers;
+    /**
+     * @deprecated Please use `embeddedNoopComments` or `embeddedNoopTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: EmbeddedCommentsOrTags;
+    [EMBEDDED_LANGUAGE_COMMENTS]?: EmbeddedCommentsOrTags;
+    [EMBEDDED_LANGUAGE_TAGS]?: EmbeddedCommentsOrTags;
   }
 }

--- a/src/embedded/pegjs/embedder.ts
+++ b/src/embedded/pegjs/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-pegjs", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-pegjs", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/pegjs/options.ts
+++ b/src/embedded/pegjs/options.ts
@@ -2,26 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-const DEFAULT_IDENTIFIERS = ["pegjs", "peggy", "peg"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["pegjs", "peggy", "peg"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -29,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedPegjsComments` or `embeddedPegjsTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/php/embedder.ts
+++ b/src/embedded/php/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("@prettier/plugin-php", options, identifier);
+  throwIfPluginIsNotFound("@prettier/plugin-php", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/php/options.ts
+++ b/src/embedded/php/options.ts
@@ -2,32 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References
- *
- * - https://github.com/microsoft/vscode/blob/de0121cf0e05d1673903551b6dbb2871556bfae9/extensions/php/package.json#L15
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L4971
- */
-const DEFAULT_IDENTIFIERS = ["php", "php5"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["php", "php5"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -35,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedPhpComments` or `embeddedPhpTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/prisma/embedder.ts
+++ b/src/embedded/prisma/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-prisma", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-prisma", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/prisma/options.ts
+++ b/src/embedded/prisma/options.ts
@@ -2,26 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-const DEFAULT_IDENTIFIERS = ["prisma"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["prisma"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -29,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedPrismaComments` or `embeddedPrismaTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/properties/embedder.ts
+++ b/src/embedded/properties/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-properties", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-properties", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/properties/options.ts
+++ b/src/embedded/properties/options.ts
@@ -2,31 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L3283
- */
-const DEFAULT_IDENTIFIERS = ["properties"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["properties"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -34,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedPropertiesComments` or `embeddedPropertiesTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/pug/embedder.ts
+++ b/src/embedded/pug/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("@prettier/plugin-pug", options, identifier);
+  throwIfPluginIsNotFound("@prettier/plugin-pug", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -60,14 +60,14 @@ export const embedder: Embedder<Options> = async (
   );
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -80,7 +80,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/pug/options.ts
+++ b/src/embedded/pug/options.ts
@@ -2,26 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-const DEFAULT_IDENTIFIERS = ["pug", "jade"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["pug", "jade"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -29,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedPugComments` or `embeddedPugTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/ruby/embedder.ts
+++ b/src/embedded/ruby/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("@prettier/plugin-ruby", options, identifier);
+  throwIfPluginIsNotFound("@prettier/plugin-ruby", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/ruby/options.ts
+++ b/src/embedded/ruby/options.ts
@@ -2,26 +2,30 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References
- *
- * - https://github.com/prettier/plugin-ruby/blob/0a2100ca3b8b53d9491270ece64806d95da181a6/src/plugin.js#L194
- */
-const DEFAULT_IDENTIFIERS = ["ruby"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["ruby"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const RUBY_PARSERS = ["ruby", "rbs", "haml"] as const;
 export type RubyParser = (typeof RUBY_PARSERS)[number];
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
 
 export const options = {
@@ -29,9 +33,26 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.",
   },
   [EMBEDDED_LANGUAGE_PARSER]: {
     category: "Embed",
@@ -50,9 +71,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedRubyComments` or `embeddedRubyTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     [EMBEDDED_LANGUAGE_PARSER]?: RubyParser;
   }
 }

--- a/src/embedded/sh/embedder.ts
+++ b/src/embedded/sh/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-sh", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-sh", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -60,14 +60,14 @@ export const embedder: Embedder<Options> = async (
   );
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -80,7 +80,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/sh/options.ts
+++ b/src/embedded/sh/options.ts
@@ -2,31 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L6445C8-L6445C8
- */
-const DEFAULT_IDENTIFIERS = ["sh"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["sh"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -34,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedShComments` or `embeddedShTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/sql/embedder.ts
+++ b/src/embedded/sql/embedder.ts
@@ -17,7 +17,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -26,7 +26,7 @@ export const embedder: Embedder<Options> = async (
 
   const plugin = resolvedOptions.embeddedSqlPlugin ?? "prettier-plugin-sql";
 
-  throwIfPluginIsNotFound(plugin, resolvedOptions, identifier);
+  throwIfPluginIsNotFound(plugin, resolvedOptions, commentOrTag);
 
   const { node } = path;
 
@@ -72,14 +72,14 @@ export const embedder: Embedder<Options> = async (
   }
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -92,7 +92,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/sql/options.ts
+++ b/src/embedded/sql/options.ts
@@ -2,24 +2,23 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
   makePluginOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References
- *
- * - https://github.com/un-ts/prettier/blob/master/packages/sql/src/index.ts "sql" is the default
- *   dialect, so we only have "sql" as the default identifier to avoid confusion.
- */
-const DEFAULT_IDENTIFIERS = ["sql"] as const;
+const DEFAULT_COMMENTS_OR_TAGS = ["sql"] as const;
 
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const SQL_PLUGINS = ["prettier-plugin-sql", "prettier-plugin-sql-cst"] as const;
 type SqlPlugin = (typeof SQL_PLUGINS)[number];
@@ -35,8 +34,9 @@ type SqlCstParser = (typeof SQL_CST_PARSERS)[number];
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
 
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 const EMBEDDED_LANGUAGE_PLUGIN = makePluginOptionName(language);
-
 const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
 
 export const options = {
@@ -44,9 +44,26 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.",
   },
   [EMBEDDED_LANGUAGE_PLUGIN]: {
     category: "Embed",
@@ -76,9 +93,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedSqlComments` or `embeddedSqlTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     [EMBEDDED_LANGUAGE_PLUGIN]?: SqlPlugin;
     [EMBEDDED_LANGUAGE_PARSER]?: SqlCstParser;
   }

--- a/src/embedded/toml/embedder.ts
+++ b/src/embedded/toml/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-toml", options, identifier);
+  throwIfPluginIsNotFound("prettier-plugin-toml", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -60,14 +60,14 @@ export const embedder: Embedder<Options> = async (
   );
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -80,7 +80,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/toml/options.ts
+++ b/src/embedded/toml/options.ts
@@ -2,31 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L6890
- */
-const DEFAULT_IDENTIFIERS = ["toml"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["toml"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.",
   },
 } as const satisfies SupportOptions;
 
@@ -34,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedTomlComments` or `embeddedTomlTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/embedded/ts/embedder.ts
+++ b/src/embedded/ts/embedder.ts
@@ -15,7 +15,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -55,14 +55,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -75,7 +75,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/ts/options.ts
+++ b/src/embedded/ts/options.ts
@@ -2,40 +2,64 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/microsoft/vscode/blob/de0121cf0e05d1673903551b6dbb2871556bfae9/extensions/typescript-basics/package.json#L24
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L7158
- */
-const DEFAULT_IDENTIFIERS = ["ts", "tsx", "cts", "mts", "typescript"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = [
+  "ts",
+  "tsx",
+  "cts",
+  "mts",
+  "typescript",
+] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 // TODO: keep in sync with prettier somehow
 const TS_PARSERS = ["typescript", "babel-ts"] as const;
-
 export type TsParser = (typeof TS_PARSERS)[number];
 
-const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
-
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
+const EMBEDDED_LANGUAGE_PARSER = makeParserOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded TypeScript language.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded TypeScript language.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded TypeScript language.",
   },
   [EMBEDDED_LANGUAGE_PARSER]: {
     category: "Embed",
@@ -53,9 +77,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedTsComments` or `embeddedTsTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     [EMBEDDED_LANGUAGE_PARSER]?: TsParser;
   }
 }

--- a/src/embedded/types.ts
+++ b/src/embedded/types.ts
@@ -1,4 +1,5 @@
 import type { Options, Parser, SupportOption } from "prettier";
+import type { LiteralUnion } from "type-fest";
 import type { Embedder } from "../types.js";
 import type { Satisfies } from "./utils.js";
 
@@ -22,7 +23,12 @@ export type EmbeddedLanguage = Satisfies<
   keyof EmbeddedLanguagesHolder
 >;
 
-export interface EmbeddedDefaultIdentifiersHolder {}
-export type EmbeddedDefaultIdentifier = keyof EmbeddedDefaultIdentifiersHolder;
+export interface EmbeddedDefaultCommentsHolder {}
+export type EmbeddedDefaultComment = keyof EmbeddedDefaultCommentsHolder;
+export type EmbeddedComment = LiteralUnion<EmbeddedDefaultComment, string>;
+
+export interface EmbeddedDefaultTagsHolder {}
+export type EmbeddedDefaultTag = keyof EmbeddedDefaultTagsHolder;
+export type EmbeddedTag = LiteralUnion<EmbeddedDefaultTag, string>;
 
 export interface PluginEmbedOptions {}

--- a/src/embedded/utils.ts
+++ b/src/embedded/utils.ts
@@ -72,7 +72,7 @@ export function simpleRehydrateDoc(
 export function throwIfPluginIsNotFound(
   pluginName: string,
   options: Options,
-  identifier: string,
+  commentOrTag: string,
 ) {
   if (
     !(
@@ -85,7 +85,7 @@ export function throwIfPluginIsNotFound(
     )
   ) {
     throw new Error(
-      `Cannot format embedded language identified by "${identifier}", because plugin "${pluginName}" is not loaded.`,
+      `Cannot format embedded language identified by "${commentOrTag}", because plugin "${pluginName}" is not loaded.`,
     );
   }
 }
@@ -157,6 +157,14 @@ export function escapeRegExp(text: string) {
 
 export function makeIdentifiersOptionName<T extends string>(language: T) {
   return `${language}Identifiers` as const;
+}
+
+export function makeCommentsOptionName<T extends string>(language: T) {
+  return `${language}Comments` as const;
+}
+
+export function makeTagsOptionName<T extends string>(language: T) {
+  return `${language}Tags` as const;
 }
 
 export function makePluginOptionName<T extends string>(language: T) {

--- a/src/embedded/xml/embedder.ts
+++ b/src/embedded/xml/embedder.ts
@@ -16,9 +16,9 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("@prettier/plugin-xml", options, identifier);
+  throwIfPluginIsNotFound("@prettier/plugin-xml", options, commentOrTag);
 
   const resolvedOptions = {
     ...options,
@@ -85,14 +85,14 @@ export const embedder: Embedder<Options> = async (
 
   if (
     resolvedOptions.xmlWhitespaceSensitivity === "strict" ||
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -105,7 +105,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/xml/options.ts
+++ b/src/embedded/xml/options.ts
@@ -2,32 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/microsoft/vscode/blob/de0121cf0e05d1673903551b6dbb2871556bfae9/extensions/xml/package.json#L15
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L7712
- */
-const DEFAULT_IDENTIFIERS = ["xml", "opml", "rss", "svg"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["xml", "opml", "rss", "svg"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.",
   },
   /**
    * @internal
@@ -46,9 +66,15 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedXmlComments` or `embeddedXmlTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
     /**
      * @internal
      */

--- a/src/embedded/yaml/embedder.ts
+++ b/src/embedded/yaml/embedder.ts
@@ -15,7 +15,7 @@ export const embedder: Embedder<Options> = async (
   print,
   path,
   options,
-  { identifier, embeddedOverrideOptions },
+  { commentOrTag, embeddedOverrideOptions },
 ) => {
   const resolvedOptions = {
     ...options,
@@ -52,14 +52,14 @@ export const embedder: Embedder<Options> = async (
   const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
 
   if (
-    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(identifier)
+    resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)
   ) {
     // TODO: should we label the doc with { hug: false } ?
     // https://github.com/prettier/prettier/blob/5cfb76ee50cf286cab267cf3cb7a26e749c995f7/src/language-js/embed/html.js#L88
     return group([
       "`",
       leadingWhitespaces,
-      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+      resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
         ? [group(contentDoc)]
         : indent([group(contentDoc)]),
       trailingWhitespaces,
@@ -72,7 +72,7 @@ export const embedder: Embedder<Options> = async (
 
   return group([
     "`",
-    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(identifier)
+    resolvedOptions.noEmbeddedMultiLineIndentation?.includes(commentOrTag)
       ? [leadingLineBreak, group(contentDoc)]
       : indent([leadingLineBreak, group(contentDoc)]),
     trailingLineBreak,

--- a/src/embedded/yaml/options.ts
+++ b/src/embedded/yaml/options.ts
@@ -2,31 +2,52 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  makeCommentsOptionName,
   makeIdentifiersOptionName,
+  makeTagsOptionName,
 } from "../utils.js";
 import { language } from "./language.js";
 
-/**
- * References:
- *
- * - https://github.com/github-linguist/linguist/blob/7ca3799b8b5f1acde1dd7a8dfb7ae849d3dfb4cd/lib/linguist/languages.yml#L7940
- */
-const DEFAULT_IDENTIFIERS = ["yaml", "yml"] as const;
-type Identifiers = AutocompleteStringList<(typeof DEFAULT_IDENTIFIERS)[number]>;
-type DefaultIdentifiersHolder = StringListToInterfaceKey<
-  typeof DEFAULT_IDENTIFIERS
->;
+const DEFAULT_COMMENTS_OR_TAGS = ["yaml", "yml"] as const;
+
+const DEFAULT_COMMENTS = DEFAULT_COMMENTS_OR_TAGS;
+type Comments = AutocompleteStringList<(typeof DEFAULT_COMMENTS)[number]>;
+type DefaultCommentsHolder = StringListToInterfaceKey<typeof DEFAULT_COMMENTS>;
+
+const DEFAULT_TAGS = DEFAULT_COMMENTS_OR_TAGS;
+type Tags = AutocompleteStringList<(typeof DEFAULT_TAGS)[number]>;
+type DefaultTagsHolder = StringListToInterfaceKey<typeof DEFAULT_TAGS>;
 
 const EMBEDDED_LANGUAGE_IDENTIFIERS = makeIdentifiersOptionName(language);
+
+const EMBEDDED_LANGUAGE_COMMENTS = makeCommentsOptionName(language);
+const EMBEDDED_LANGUAGE_TAGS = makeTagsOptionName(language);
 
 export const options = {
   [EMBEDDED_LANGUAGE_IDENTIFIERS]: {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [...DEFAULT_IDENTIFIERS] }],
+    default: [{ value: [...DEFAULT_COMMENTS_OR_TAGS] }],
     description:
       "Tag or comment identifiers that make their subsequent template literals be identified as embedded YAML language.",
+    deprecated: `Please use \`${EMBEDDED_LANGUAGE_COMMENTS}\` or \`${EMBEDDED_LANGUAGE_TAGS}\`.`,
+  },
+  [EMBEDDED_LANGUAGE_COMMENTS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Block comments that make their subsequent template literals be identified as embedded YAML language.",
+  },
+  [EMBEDDED_LANGUAGE_TAGS]: {
+    category: "Embed",
+    type: "string",
+    array: true,
+    default: [{ value: [] }],
+    description:
+      "Tags that make their subsequent template literals be identified as embedded YAML language.",
   },
 } as const satisfies SupportOptions;
 
@@ -34,8 +55,14 @@ type Options = typeof options;
 
 declare module "../types.js" {
   interface EmbeddedOptions extends Options {}
-  interface EmbeddedDefaultIdentifiersHolder extends DefaultIdentifiersHolder {}
+  interface EmbeddedDefaultCommentsHolder extends DefaultCommentsHolder {}
+  interface EmbeddedDefaultTagsHolder extends DefaultTagsHolder {}
   interface PluginEmbedOptions {
-    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: Identifiers;
+    /**
+     * @deprecated Please use `embeddedYamlComments` or `embeddedYamlTags`.
+     */
+    [EMBEDDED_LANGUAGE_IDENTIFIERS]?: (Comments[number] | Tags[number])[];
+    [EMBEDDED_LANGUAGE_COMMENTS]?: Comments;
+    [EMBEDDED_LANGUAGE_TAGS]?: Tags;
   }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,37 +1,49 @@
 import type { SupportOptions } from "prettier";
 import {
-  type AutocompleteStringList,
-  type EmbeddedDefaultIdentifier,
+  type EmbeddedComment,
+  type EmbeddedTag,
   embeddedOptions,
 } from "./embedded/index.js";
 
-type EmbeddedIdentifiers = AutocompleteStringList<EmbeddedDefaultIdentifier>;
+type EmbeddedCommentsOrTags = (EmbeddedComment | EmbeddedTag)[];
 
-const NO_EMBEDDED_IDENTIFICATION_BY_COMMENT =
-  "noEmbeddedIdentificationByComment";
+// biome-ignore format: no line break
+const NO_EMBEDDED_IDENTIFICATION_BY_COMMENT = "noEmbeddedIdentificationByComment";
+// biome-ignore format: no line break
 const NO_EMBEDDED_IDENTIFICATION_BY_TAG = "noEmbeddedIdentificationByTag";
-const PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES =
-  "preserveEmbeddedExteriorWhitespaces";
+// biome-ignore format: no line break
+const PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES = "preserveEmbeddedExteriorWhitespaces";
+// biome-ignore format: no line break
 const NO_EMBEDDED_MULTI_LINE_INDENTATION = "noEmbeddedMultiLineIndentation";
 const EMBEDDED_OVERRIDES = "embeddedOverrides";
 
 export const options = {
   ...embeddedOptions,
+  /**
+   * @deprecated Please use `embedded<Language>Comments` or `embedded<Language>Tags` to configure each embedded language, and you won't need this option anymore.
+   */
   [NO_EMBEDDED_IDENTIFICATION_BY_COMMENT]: {
     category: "Embed",
     type: "string",
     array: true,
     default: [{ value: [] }],
     description:
-      "Turns off `` /* identifier */ `...` `` comment-based embedded language identification for the specified identifiers.",
+      "Turns off `` /* comment */ `...` `` comment-based embedded language identification for the specified identifiers.",
+    deprecated:
+      "Please use `embedded<Language>Comments` or `embedded<Language>Tags` to configure each embedded language, and you won't need this option anymore.",
   },
+  /**
+   * @deprecated Please use `embedded<Language>Comments` or `embedded<Language>Tags` to configure each embedded language, and you won't need this option anymore.
+   */
   [NO_EMBEDDED_IDENTIFICATION_BY_TAG]: {
     category: "Embed",
     type: "string",
     array: true,
     default: [{ value: [] }],
     description:
-      "Turns off `` identifier`...` `` tag-based embedded language identification for the specified identifiers.",
+      "Turns off `` tag`...` `` tag-based embedded language identification for the specified identifiers.",
+    deprecated:
+      "Please use `embedded<Language>Comments` or `embedded<Language>Tags` to configure each embedded language, and you won't need this option anymore.",
   },
   [PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES]: {
     category: "Embed",
@@ -39,7 +51,7 @@ export const options = {
     array: true,
     default: [{ value: [] }],
     description:
-      "Preserves leading and trailing whitespaces in the formatting results for the specified identifiers.",
+      "Preserves leading and trailing whitespaces in the formatting results for the specified comments or tags.",
   },
   [NO_EMBEDDED_MULTI_LINE_INDENTATION]: {
     category: "Embed",
@@ -47,7 +59,7 @@ export const options = {
     array: true,
     default: [{ value: [] }],
     description:
-      "Turns off auto indentation in the formatting results for the specified identifiers when they are formatted to span multi lines.",
+      "Turns off auto indentation in the formatting results for the specified comments or tags when they are formatted to span multi lines.",
   },
   [EMBEDDED_OVERRIDES]: {
     category: "Embed",
@@ -55,15 +67,21 @@ export const options = {
     array: false,
     default: undefined,
     description:
-      "Option overrides for the specified identifiers. It should either be a stringified JSON or an absolute filepath to the option overrides file.",
+      "Option overrides for the specified comments or tags. It should either be a stringified JSON or an absolute filepath to the option overrides file.",
   },
 } as const satisfies SupportOptions;
 
 export interface PluginEmbedLanguageAgnosticOptions {
-  [NO_EMBEDDED_IDENTIFICATION_BY_COMMENT]?: EmbeddedIdentifiers;
-  [NO_EMBEDDED_IDENTIFICATION_BY_TAG]?: EmbeddedIdentifiers;
-  [PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES]?: EmbeddedIdentifiers;
-  [NO_EMBEDDED_MULTI_LINE_INDENTATION]?: EmbeddedIdentifiers;
+  /**
+   * @deprecated Please use `embedded<Language>Comments` or `embedded<Language>Tags` to configure each embedded language, and you won't need this option anymore.
+   */
+  [NO_EMBEDDED_IDENTIFICATION_BY_COMMENT]?: EmbeddedCommentsOrTags;
+  /**
+   * @deprecated Please use `embedded<Language>Comments` or `embedded<Language>Tags` to configure each embedded language, and you won't need this option anymore.
+   */
+  [NO_EMBEDDED_IDENTIFICATION_BY_TAG]?: EmbeddedCommentsOrTags;
+  [PRESERVE_EMBEDDED_EXTERIOR_WHITESPACES]?: EmbeddedCommentsOrTags;
+  [NO_EMBEDDED_MULTI_LINE_INDENTATION]?: EmbeddedCommentsOrTags;
   [EMBEDDED_OVERRIDES]?: string;
 }
 


### PR DESCRIPTION
Deprecate `identifier`-named options in favor of `tag` and `comment`:

Quote from #66
> `identifier` is not intuitive and is easily confused with [the `identifier` in JavaScript](https://developer.mozilla.org/en-US/docs/Glossary/Identifier).
> 
> It should be replaced by `tag` and `comment`. For backward compatibility before its full removal, values set in `identifier` should be applied to both `tag` and `comment`.

What this PR changes:

- `embedded<Language>Identifiers` -> `embedded<Language>Comments` and `embedded<Language>Tags`
- Doesn't need ~~`noEmbeddedIdentificationByComment`~~ anymore.
- Doesn't need ~~`noEmbeddedIdentificationByTag`~~ anymore.
- `embeddedOverrides` now takes the form: `{"comments": [...], "options": {...}}` or `{"tags": [...], "options": {...}}` or `{"comments": [...], "tags": [...], "options": {...}}`
- If `comment`- or `tag`-named options are not present, the plugin will fallback to use `identifier`-named options.
- README updated to reflect the above changes.
- **No** breaking change. You can still use the old config and it should work. If it does not, please add comments to tell me.

Closes #66

cc @JounQin @fisker

Some other users I know of who use this plugin, apologize for the ping: @karlhorky @innermatrix @nene @jaydenseric @ehoogeveen-medweb 