### PR TITLE
Disable language plugin check

### DIFF
--- a/.changeset/angry-countries-serve.md
+++ b/.changeset/angry-countries-serve.md
@@ -1,0 +1,7 @@
+---
+"prettier-plugin-embed": patch
+---
+
+Fix language plugin check false positives.
+
+`throwIfPluginIsNotFound` is discarded. Detailed explanation can be found at https://github.com/Sec-ant/prettier-plugin-embed/issues/84#issuecomment-1953844934.

--- a/src/embedded/glsl/embedder.ts
+++ b/src/embedded/glsl/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-glsl", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/ini/embedder.ts
+++ b/src/embedded/ini/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-ini", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/java/embedder.ts
+++ b/src/embedded/java/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-java", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/jsonata/embedder.ts
+++ b/src/embedded/jsonata/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,12 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound(
-    "@stedi/prettier-plugin-jsonata",
-    options,
-    commentOrTag,
-  );
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/latex/embedder.ts
+++ b/src/embedded/latex/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-latex", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/nginx/embedder.ts
+++ b/src/embedded/nginx/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-nginx", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/pegjs/embedder.ts
+++ b/src/embedded/pegjs/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-pegjs", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/php/embedder.ts
+++ b/src/embedded/php/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("@prettier/plugin-php", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/prisma/embedder.ts
+++ b/src/embedded/prisma/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-prisma", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/properties/embedder.ts
+++ b/src/embedded/properties/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-properties", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/pug/embedder.ts
+++ b/src/embedded/pug/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("@prettier/plugin-pug", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/ruby/embedder.ts
+++ b/src/embedded/ruby/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("@prettier/plugin-ruby", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/sh/embedder.ts
+++ b/src/embedded/sh/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-sh", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/sql/embedder.ts
+++ b/src/embedded/sql/embedder.ts
@@ -6,7 +6,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -25,8 +24,6 @@ export const embedder: Embedder<Options> = async (
   };
 
   const plugin = resolvedOptions.embeddedSqlPlugin ?? "prettier-plugin-sql";
-
-  throwIfPluginIsNotFound(plugin, resolvedOptions, commentOrTag);
 
   const { node } = path;
 

--- a/src/embedded/toml/embedder.ts
+++ b/src/embedded/toml/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("prettier-plugin-toml", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,

--- a/src/embedded/utils.ts
+++ b/src/embedded/utils.ts
@@ -1,5 +1,5 @@
 import type { Comment, Expression, TemplateLiteral } from "estree";
-import type { AstPath, Doc, Options } from "prettier";
+import type { AstPath, Doc } from "prettier";
 import { builders, utils } from "prettier/doc";
 import type {
   LiteralUnion,
@@ -67,27 +67,6 @@ export function simpleRehydrateDoc(
     return parts;
   });
   return contentDoc;
-}
-
-export function throwIfPluginIsNotFound(
-  pluginName: string,
-  options: Options,
-  commentOrTag: string,
-) {
-  if (
-    !(
-      options.plugins?.some(
-        (p) =>
-          (p as { name?: string }).name?.match(
-            new RegExp(`(^|/)${escapeRegExp(pluginName)}($|/)`),
-          ) ?? false,
-      ) ?? false
-    )
-  ) {
-    throw new Error(
-      `Cannot format embedded language identified by "${commentOrTag}", because plugin "${pluginName}" is not loaded.`,
-    );
-  }
 }
 
 export function insertLanguage(

--- a/src/embedded/xml/embedder.ts
+++ b/src/embedded/xml/embedder.ts
@@ -5,7 +5,6 @@ import {
   preparePlaceholder,
   printTemplateExpressions,
   simpleRehydrateDoc,
-  throwIfPluginIsNotFound,
 } from "../utils.js";
 import { language } from "./language.js";
 
@@ -18,8 +17,6 @@ export const embedder: Embedder<Options> = async (
   options,
   { commentOrTag, embeddedOverrideOptions },
 ) => {
-  throwIfPluginIsNotFound("@prettier/plugin-xml", options, commentOrTag);
-
   const resolvedOptions = {
     ...options,
     ...embeddedOverrideOptions,


### PR DESCRIPTION
Disable language plugin check because of false positives (#58, #84) and edge cases across platforms. The original check mechanism also prevents loading custom plugins. Check https://github.com/Sec-ant/prettier-plugin-embed/issues/84#issuecomment-1953844934 for a detailed explanation.

Fixes #84.