### PR TITLE
Fix options fallback and CSS formatting behavior

### DIFF
--- a/.changeset/many-otters-applaud.md
+++ b/.changeset/many-otters-applaud.md
@@ -1,0 +1,7 @@
+---
+"prettier-plugin-embed": patch
+---
+
+Fix wrong options fallback behaviors:
+
+- Empty list of tags and comments shouldn't fallback to identifiers in options.

--- a/.changeset/silver-rings-dress.md
+++ b/.changeset/silver-rings-dress.md
@@ -1,0 +1,5 @@
+---
+"prettier-plugin-embed": patch
+---
+
+Make embedded `css` formatting more align with the built-in behavior.

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@
 *.tsx
 *.json
 *.jsonc
+.all-contributorsrc

--- a/src/embedded/css/embedder.ts
+++ b/src/embedded/css/embedder.ts
@@ -24,7 +24,10 @@ export const embedder: Embedder<Options> = async (
 
   const { node } = path;
 
-  const { createPlaceholder, placeholderRegex } = preparePlaceholder("@p");
+  // https://github.com/prettier/prettier/blob/3bfabd012873e5022f341aca75566966d91870f1/src/language-css/utils/index.js#L206-L208
+  const { createPlaceholder, placeholderRegex } = preparePlaceholder(
+    "@prettier-placeholder",
+  );
 
   const text = node.quasis
     .map((quasi, index, { length }) =>
@@ -49,7 +52,13 @@ export const embedder: Embedder<Options> = async (
     parser: resolvedOptions.embeddedCssParser ?? "scss",
   });
 
-  const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
+  const contentDoc = simpleRehydrateDoc(
+    doc,
+    placeholderRegex,
+    expressionDocs,
+    // https://github.com/prettier/prettier/blob/3bfabd012873e5022f341aca75566966d91870f1/src/language-js/embed/css.js#L52
+    true,
+  );
 
   if (
     resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)

--- a/src/embedded/css/options.ts
+++ b/src/embedded/css/options.ts
@@ -2,6 +2,7 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
@@ -42,7 +43,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded CSS language.",
   },
@@ -50,7 +51,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded CSS language.",
   },

--- a/src/embedded/es/options.ts
+++ b/src/embedded/es/options.ts
@@ -2,6 +2,7 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
@@ -59,7 +60,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.",
   },
@@ -67,7 +68,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded ECMAScript/JavaScript language.",
   },

--- a/src/embedded/glsl/options.ts
+++ b/src/embedded/glsl/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded GLSL language. This option requires the `prettier-plugin-glsl` plugin.",
   },

--- a/src/embedded/graphql/options.ts
+++ b/src/embedded/graphql/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded GraphQL language.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded GraphQL language.",
   },

--- a/src/embedded/html/options.ts
+++ b/src/embedded/html/options.ts
@@ -2,6 +2,7 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
@@ -42,7 +43,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded HTML language.",
   },
@@ -50,7 +51,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded HTML language.",
   },

--- a/src/embedded/index.ts
+++ b/src/embedded/index.ts
@@ -14,5 +14,6 @@ export {
   makeIdentifiersOptionName,
   makeCommentsOptionName,
   makeTagsOptionName,
+  fallbackIndicator,
   type AutocompleteStringList,
 } from "./utils.js";

--- a/src/embedded/ini/options.ts
+++ b/src/embedded/ini/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded INI language. This option requires the `prettier-plugin-ini` plugin.",
   },

--- a/src/embedded/java/options.ts
+++ b/src/embedded/java/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded Java language. This option requires the `prettier-plugin-java` plugin.",
   },

--- a/src/embedded/json/options.ts
+++ b/src/embedded/json/options.ts
@@ -2,6 +2,7 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
@@ -43,7 +44,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded JSON language.",
   },
@@ -51,7 +52,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded JSON language.",
   },

--- a/src/embedded/jsonata/options.ts
+++ b/src/embedded/jsonata/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded JSONata language. This option requires the `@stedi/prettier-plugin-jsonata` plugin.",
   },

--- a/src/embedded/latex/options.ts
+++ b/src/embedded/latex/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -46,7 +47,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.",
   },
@@ -54,7 +55,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded LaTeX language. This option requires the `prettier-plugin-latex` plugin.",
   },

--- a/src/embedded/markdown/options.ts
+++ b/src/embedded/markdown/options.ts
@@ -2,6 +2,7 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
@@ -42,7 +43,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded Markdown language.",
   },
@@ -50,7 +51,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded Markdown language.",
   },

--- a/src/embedded/nginx/options.ts
+++ b/src/embedded/nginx/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded NGINX language. This option requires the `prettier-plugin-nginx` plugin.",
   },

--- a/src/embedded/noop/options.ts
+++ b/src/embedded/noop/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import type { EmbeddedDefaultComment, EmbeddedDefaultTag } from "../types.js";
 import {
   type AutocompleteStringList,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -31,7 +32,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.",
   },
@@ -39,7 +40,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that prevent their subsequent template literals from being identified as embedded languages and thus from being formatted.",
   },

--- a/src/embedded/pegjs/options.ts
+++ b/src/embedded/pegjs/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded Pegjs language. This option requires the `prettier-plugin-pegjs` plugin.",
   },

--- a/src/embedded/php/options.ts
+++ b/src/embedded/php/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded PHP language. This option requires the `@prettier/plugin-php` plugin.",
   },

--- a/src/embedded/prisma/options.ts
+++ b/src/embedded/prisma/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded Prisma language. This option requires the `prettier-plugin-prisma` plugin.",
   },

--- a/src/embedded/properties/options.ts
+++ b/src/embedded/properties/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded Properties language. This option requires the `prettier-plugin-properties` plugin.",
   },

--- a/src/embedded/pug/options.ts
+++ b/src/embedded/pug/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded Pug language. This option requires the `@prettier/plugin-pug` plugin.",
   },

--- a/src/embedded/ruby/options.ts
+++ b/src/embedded/ruby/options.ts
@@ -2,6 +2,7 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
@@ -42,7 +43,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.",
   },
@@ -50,7 +51,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded Ruby language. This option requires the `@prettier/plugin-ruby` plugin.",
   },

--- a/src/embedded/sh/options.ts
+++ b/src/embedded/sh/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded Shell language. This option requires the `prettier-plugin-sh` plugin.",
   },

--- a/src/embedded/sql/options.ts
+++ b/src/embedded/sql/options.ts
@@ -2,6 +2,7 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
@@ -53,7 +54,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.",
   },
@@ -61,7 +62,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded SQL language. This option requires the `prettier-plugin-sql` plugin or the `prettier-plugin-sql-cst` plugin.",
   },

--- a/src/embedded/toml/options.ts
+++ b/src/embedded/toml/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded TOML language. This option requires the `prettier-plugin-toml` plugin.",
   },

--- a/src/embedded/ts/options.ts
+++ b/src/embedded/ts/options.ts
@@ -2,6 +2,7 @@ import type { ChoiceSupportOption, SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeParserOptionName,
@@ -49,7 +50,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded TypeScript language.",
   },
@@ -57,7 +58,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded TypeScript language.",
   },

--- a/src/embedded/utils.ts
+++ b/src/embedded/utils.ts
@@ -170,3 +170,5 @@ export type NormalizeOptions<T> = OmitIndexSignature<{
     ? T[k]
     : UnionToIntersection<T>[k];
 }>;
+
+export const fallbackIndicator = "9ff2b366e8ca4c97b9aed1a29b5b94ed";

--- a/src/embedded/xml/options.ts
+++ b/src/embedded/xml/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded XML language. This option requires the `@prettier/plugin-xml` plugin.",
   },

--- a/src/embedded/yaml/options.ts
+++ b/src/embedded/yaml/options.ts
@@ -2,6 +2,7 @@ import type { SupportOptions } from "prettier";
 import {
   type AutocompleteStringList,
   type StringListToInterfaceKey,
+  fallbackIndicator,
   makeCommentsOptionName,
   makeIdentifiersOptionName,
   makeTagsOptionName,
@@ -37,7 +38,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Block comments that make their subsequent template literals be identified as embedded YAML language.",
   },
@@ -45,7 +46,7 @@ export const options = {
     category: "Embed",
     type: "string",
     array: true,
-    default: [{ value: [] }],
+    default: [{ value: [fallbackIndicator] }],
     description:
       "Tags that make their subsequent template literals be identified as embedded YAML language.",
   },


### PR DESCRIPTION
- Empty list of tags and comments shouldn't fallback to identifiers.
- Make embedded `css` formatting more align with the built-in behavior.

Fixes #88.