### PR TITLE
Fix unstable code block indentation in markdown

### DIFF
--- a/src/embedded/markdown/embedder.ts
+++ b/src/embedded/markdown/embedder.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import type { Options } from "prettier";
 import { builders } from "prettier/doc";
 import type { Embedder } from "../../types.js";
@@ -44,13 +45,13 @@ export const embedder: Embedder<Options> = async (
 
   const expressionDocs = printTemplateExpressions(path, print);
 
-  const doc = await textToDoc(trimmedText, {
+  const doc = await textToDoc(dedent(trimmedText), {
     ...resolvedOptions,
     parser: resolvedOptions.embeddedMarkdownParser ?? "markdown",
     __inJsTemplate: true,
   });
 
-  const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs);
+  const contentDoc = simpleRehydrateDoc(doc, placeholderRegex, expressionDocs, true);
 
   if (
     resolvedOptions.preserveEmbeddedExteriorWhitespaces?.includes(commentOrTag)


### PR DESCRIPTION
I was running into the same indentation problems when formatting embedded markdown as seen in #45. 

Trying the dedent workaround in #50 in the markdown embeddder fixed the issue for me